### PR TITLE
매매 제안 관련 api에 예외 처리 추가

### DIFF
--- a/group-investment/src/main/java/com/example/group_investment/rabbitMq/RabbitMqConfig.java
+++ b/group-investment/src/main/java/com/example/group_investment/rabbitMq/RabbitMqConfig.java
@@ -27,7 +27,7 @@ public class RabbitMqConfig {
     private String rabbitmqPassword;
 
     @Value("${spring.rabbitmq.fcm-queue.name}")
-    private String QueueName;
+    private String queueName;
 
     @Value("${spring.rabbitmq.main-stock-queue.name}")
     private String stockQueueName;
@@ -35,7 +35,7 @@ public class RabbitMqConfig {
 
     @Bean
     public Queue mainToAlarmQueue() {
-        return new Queue(QueueName, true);
+        return new Queue(queueName, true);
     }
 
     @Bean

--- a/group-investment/src/main/java/com/example/group_investment/rabbitMq/RabbitMqConfig.java
+++ b/group-investment/src/main/java/com/example/group_investment/rabbitMq/RabbitMqConfig.java
@@ -35,7 +35,7 @@ public class RabbitMqConfig {
 
     @Bean
     public Queue mainToAlarmQueue() {
-        return new Queue(alarmQueueName, true);
+        return new Queue(QueueName, true);
     }
 
     @Bean

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferController.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferController.java
@@ -18,15 +18,18 @@ public class TradeOfferController {
 
     @Operation(summary = "매매 제안 생성", description = "매매 제안을 생성하는 api입니다.")
     @PostMapping
-    public ApiResponse createTradeOffer(@RequestBody CreateTradeOfferRequest createTradeOfferRequest) {
-        tradeOfferService.createTradeOffer(createTradeOfferRequest);
+    public ApiResponse createTradeOffer(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId,
+                                        @RequestBody CreateTradeOfferRequest createTradeOfferRequest) {
+        System.out.println("userId: " + userId + ", teamId: " + teamId + ", createTradeOfferRequest: " + createTradeOfferRequest.getQuantity());
+        tradeOfferService.createTradeOffer(userId, teamId, createTradeOfferRequest);
         return new ApiResponse(201, true, "매매제안을 생성했습니다.", null);
     }
 
     @Operation(summary = "매매 제안 조회", description = "매매 제안 리스트를 조회하는 api입니다.")
     @GetMapping
-    public ApiResponse<GetAllTradeOffersResponse> getAllTradeOffers(@RequestParam TradeType type, @RequestParam int page, @RequestParam int size) {
-        return new ApiResponse(200, true, "매매제안을 조회했습니다.", tradeOfferService.getAllTradeOffers(type, page, size));
+    public ApiResponse<GetAllTradeOffersResponse> getAllTradeOffers(@RequestAttribute("teamId") int teamId,
+                                                                    @RequestParam TradeType type, @RequestParam int page, @RequestParam int size) {
+        return new ApiResponse(200, true, "매매제안을 조회했습니다.", tradeOfferService.getAllTradeOffers(teamId, type, page, size));
     }
 
     @Operation(summary = "매매 제안 투표", description = "매매 제안에 투표하는 api입니다.")

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferService.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferService.java
@@ -63,6 +63,16 @@ public class TradeOfferService {
         Rule rule = ruleRepository.findByTeam(team).orElseThrow(
                 () -> new RuleException(RuleErrorCode.RULE_NOT_FOUND));
 
+        if (createTradeOfferRequest.getTradeType() == TradeType.SELL) {
+            if (createTradeOfferRequest.getQuantity() > (tradeOfferCommunicator.getNumOfHoldingsFromStockSystem(teamId, createTradeOfferRequest.getCode()) + tradeOfferCommunicator.getNumOfPendingTradeFromStockSystem(teamId, createTradeOfferRequest.getCode()))) {
+                throw new TradeOfferException(TradeOfferErrorCode.HOLDINGS_NOT_ENOUGH);
+            }
+        } else {
+            if (createTradeOfferRequest.getQuantity() * createTradeOfferRequest.getWantPrice() > tradeOfferCommunicator.getAvailableAssetFromStockSystem(teamId)) {
+                throw new TradeOfferException(TradeOfferErrorCode.ASSET_NOT_ENOUGH);
+            }
+        }
+
         TradeOfferDto tradeOfferDto;
         if (createTradeOfferRequest.getTradeType() == TradeType.SELL && tradeOfferCommunicator.getPrdyVrssRtFromStockSystem(createTradeOfferRequest.getCode()) <= ((-1) * rule.getPrdyVrssRt())) {
             tradeOfferDto = tradeOfferConverter.createTradeOfferRequestToUrgentTradeOfferDto(createTradeOfferRequest, member, team);

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferService.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferService.java
@@ -52,10 +52,7 @@ public class TradeOfferService {
     @Value("${spring.rabbitmq.main-stock-queue.name}")
     private String mainStockQueue;
 
-    public void createTradeOffer(CreateTradeOfferRequest createTradeOfferRequest) {
-        // FIXME: 토큰으로 사용자 아이디와 모임 아이디 가져와야함
-        int userId = 1;
-        int teamId = 1;
+    public void createTradeOffer(int userId, int teamId, CreateTradeOfferRequest createTradeOfferRequest) {
 
         Member member = memberRepository.findByUserIdAndTeamId(userId, teamId).orElseThrow(
                 () -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -80,10 +77,7 @@ public class TradeOfferService {
         }
     }
 
-    public GetAllTradeOffersResponse getAllTradeOffers(TradeType type, int page, int size) {
-        // FIXME: 토큰으로 사용자 아이디와 모임 아이디 가져와야함
-        int userId = 1;
-        int teamId = 1;
+    public GetAllTradeOffersResponse getAllTradeOffers(int teamId, TradeType type, int page, int size) {
 
         Team team = teamRepository.findById(teamId).orElseThrow(
                 () -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferService.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/TradeOfferService.java
@@ -103,7 +103,22 @@ public class TradeOfferService {
             }
         }
 
-        List<TradeOfferResponse> tradeOfferResponses = tradeOfferConverter.tradeOfferListToTradeOfferResponseList(tradeOffers);
+        List<TradeOfferResponse> tradeOfferResponses = tradeOffers.stream()
+                .map(tradeOffer -> new TradeOfferResponse().builder()
+                        .tradeOfferId(tradeOffer.getId())
+                        .userName(tradeOffer.getMember().getUser().getName())
+                        .stockName(tradeOfferCommunicator.getStockNameFromStockSystem(tradeOffer.getStockCode()).getName())
+                        .tradeType(tradeOffer.getTradeType())
+                        .offerStatus(tradeOffer.getOfferStatus())
+                        .wantPrice(tradeOffer.getWantPrice())
+                        .quantity(tradeOffer.getQuantity())
+                        .offerAt(tradeOffer.getOfferAt().toLocalDate().toString())
+                        .isUrgent(tradeOffer.isUrgent())
+                        .upvotes(tradeOffer.getUpvotes())
+                        .downvotes(tradeOffer.getDownvotes())
+                        .isVote(tradeOfferVoteRepository.existsByTradeOfferAndMember(tradeOffer, tradeOffer.getMember()))
+                        .build())
+                .toList();
 
         return new GetAllTradeOffersResponse().builder()
                 .tradeOfferResponses(tradeOfferResponses)

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/dto/TradeOfferDto.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/dto/TradeOfferDto.java
@@ -5,7 +5,9 @@ import com.example.group_investment.member.Member;
 import com.example.group_investment.team.Team;
 import com.example.group_investment.tradeOffer.TradeOffer;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class TradeOfferDto {
     private Member member;
     private Team team;

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/dto/TradeOfferResponse.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/dto/TradeOfferResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 @Getter
 public class TradeOfferResponse {
+    private int tradeOfferId;
     private String userName;
     private TradeType tradeType;
     private String stockName;
@@ -17,12 +18,14 @@ public class TradeOfferResponse {
     private OfferStatus offerStatus;
     private int upvotes;
     private int downvotes;
+    private boolean isVote;
 
     public TradeOfferResponse() {
     }
 
     @Builder
-    public TradeOfferResponse(String userName, TradeType tradeType, String stockName, int wantPrice, int quantity, String offerAt, boolean isUrgent, OfferStatus offerStatus, int upvotes, int downvotes) {
+    public TradeOfferResponse(int tradeOfferId, String userName, TradeType tradeType, String stockName, int wantPrice, int quantity, String offerAt, boolean isUrgent, OfferStatus offerStatus, int upvotes, int downvotes, boolean isVote) {
+        this.tradeOfferId = tradeOfferId;
         this.userName = userName;
         this.tradeType = tradeType;
         this.stockName = stockName;
@@ -33,5 +36,6 @@ public class TradeOfferResponse {
         this.offerStatus = offerStatus;
         this.upvotes = upvotes;
         this.downvotes = downvotes;
+        this.isVote = isVote;
     }
 }

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/exception/TradeOfferErrorCode.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/exception/TradeOfferErrorCode.java
@@ -4,9 +4,13 @@ import lombok.Getter;
 
 @Getter
 public enum TradeOfferErrorCode {
-    TRADE_OFFER_NOT_FOUND(404, "AG401", "매매제안이 존재하지 않습니다."),
     STOCKS_SERVER_BAD_REQUEST(400, "AG001", "증권 시스템 서버 요청에 실패했습니다."),
-    TRADE_OFFER_EXPIRED(400, "AG001", "만료된 제안입니다.");
+    ASSET_NOT_ENOUGH(402, "AG201", "자산이 부족합니다."),
+    TRADE_OFFER_EXPIRED(403, "AG301", "만료된 제안입니다."),
+    TRADE_OFFER_NOT_FOUND(404, "AG401", "매매제안이 존재하지 않습니다."),
+    HOLDINGS_NOT_ENOUGH(409, "AG903", "보유 수량이 충분하지 않습니다."),
+    ALREADY_VOTED(409, "AG902", "이미 투표한 매매제안입니다."),
+    ;
 
     private final int status;
     private final String divisionCode;

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/utils/TradeOfferCommunicator.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/utils/TradeOfferCommunicator.java
@@ -51,4 +51,55 @@ public class TradeOfferCommunicator {
 
         return prdyVrssRt.getData();
     }
+
+    public int getNumOfHoldingsFromStockSystem(int teamId, String code) {
+        WebClient webClient = webClientBuilder.build();
+
+        ApiResponse<Integer> numOfHoldings = webClient.get()
+                .uri(AG_URL + ":8082/api/backend/holdings/count?teamId=" + teamId + "&code=" + code)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<ApiResponse<Integer>>() {
+                })
+                .block();
+
+        if (!numOfHoldings.isSuccess()) {
+            throw new TradeOfferException(TradeOfferErrorCode.STOCKS_SERVER_BAD_REQUEST);
+        }
+
+        return numOfHoldings.getData();
+    }
+
+    public int getNumOfPendingTradeFromStockSystem(int teamId, String code) {
+        WebClient webClient = webClientBuilder.build();
+
+        ApiResponse<Integer> numOfPendingTrade = webClient.get()
+                .uri(AG_URL + ":8082/api/backend/trades/count?teamId=" + teamId + "&code=" + code)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<ApiResponse<Integer>>() {
+                })
+                .block();
+
+        if (!numOfPendingTrade.isSuccess()) {
+            throw new TradeOfferException(TradeOfferErrorCode.STOCKS_SERVER_BAD_REQUEST);
+        }
+
+        return numOfPendingTrade.getData();
+    }
+
+    public int getAvailableAssetFromStockSystem(int teamId) {
+        WebClient webClient = webClientBuilder.build();
+
+        ApiResponse<Integer> restAsset = webClient.get()
+                .uri(AG_URL + ":8082/api/backend/accounts/asset?teamId=" + teamId)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<ApiResponse<Integer>>() {
+                })
+                .block();
+
+        if (!restAsset.isSuccess()) {
+            throw new TradeOfferException(TradeOfferErrorCode.STOCKS_SERVER_BAD_REQUEST);
+        }
+
+        return restAsset.getData();
+    }
 }

--- a/group-investment/src/main/java/com/example/group_investment/tradeOffer/utils/TradeOfferConverter.java
+++ b/group-investment/src/main/java/com/example/group_investment/tradeOffer/utils/TradeOfferConverter.java
@@ -6,36 +6,13 @@ import com.example.group_investment.tradeOffer.TradeOffer;
 import com.example.group_investment.tradeOffer.dto.CreateTradeOfferRequest;
 import com.example.group_investment.tradeOffer.dto.CreateTradeRequest;
 import com.example.group_investment.tradeOffer.dto.TradeOfferDto;
-import com.example.group_investment.tradeOffer.dto.TradeOfferResponse;
 import lombok.AllArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
-
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 @Component
 @AllArgsConstructor
 public class TradeOfferConverter {
     private final TradeOfferCommunicator tradeOfferCommunicator;
-
-    public List<TradeOfferResponse> tradeOfferListToTradeOfferResponseList(Page<TradeOffer> tradeOffers) {
-        return tradeOffers.stream()
-                .map(tradeOffer -> new TradeOfferResponse().builder()
-                        .userName(tradeOffer.getMember().getUser().getName())
-                        .stockName(tradeOfferCommunicator.getStockNameFromStockSystem(tradeOffer.getStockCode()).getName())
-                        .tradeType(tradeOffer.getTradeType())
-                        .offerStatus(tradeOffer.getOfferStatus())
-                        .wantPrice(tradeOffer.getWantPrice())
-                        .quantity(tradeOffer.getQuantity())
-                        .offerAt(tradeOffer.getOfferAt().toLocalDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
-                        .isUrgent(tradeOffer.isUrgent())
-                        .userName(tradeOffer.getMember().getUser().getName())
-                        .upvotes(tradeOffer.getUpvotes())
-                        .downvotes(tradeOffer.getDownvotes())
-                        .build())
-                .toList();
-    }
 
     public TradeOfferDto createTradeOfferRequestToUrgentTradeOfferDto(CreateTradeOfferRequest createTradeOfferRequest, Member member, Team team) {
         return new TradeOfferDto().builder()

--- a/stock-system/src/main/java/com/example/stock_system/backend_only/BackendController.java
+++ b/stock-system/src/main/java/com/example/stock_system/backend_only/BackendController.java
@@ -32,4 +32,22 @@ public class BackendController {
         return new ApiResponse<>(200, true, "전일 대비 등락율을 조회했습니다.", stocksService.getCurrentData(code).getChangeRate());
     }
 
+    @Operation(summary = "(백엔드 전용)계좌 보유 종목 수 조회", description = "보유 종목 수를 조회하는 API")
+    @GetMapping(value = "/holdings/count")
+    public ApiResponse<Integer> getNumOfHoldings(@RequestParam int teamId, @RequestParam String code) {
+        return new ApiResponse<>(200, true, "보유 종목 수를 조회했습니다.", holdingsService.getNumOfHoldings(teamId, code));
+    }
+
+
+    @Operation(summary = "(백엔드 전용)주문 개수 조회", description = "pending 상태의 주문 개수를 조회하는 API")
+    @GetMapping("/trades/count")
+    public ApiResponse<Integer> getNumOfTrades(@RequestParam int teamId, @RequestParam String code) {
+        return new ApiResponse<>(200, true, "주문 개수를 조회했습니다.", tradeService.getNumOfSellingTrades(teamId, code));
+    }
+
+    @Operation(summary = "(백엔드 전용)거래 가능한 예수금 조회", description = "예수금에서 매수 주문 금액을 제외한 여분의 예수금을 조회하는 API")
+    @GetMapping("/accounts/asset")
+    public ApiResponse<Integer> getAvailableAsset(@RequestParam int teamId) {
+        return new ApiResponse<>(200, true, "거래 가능한 예수금을 조회했습니다.", holdingsService.getAvailableAsset(teamId));
+    }
 }

--- a/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsController.java
+++ b/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsController.java
@@ -22,14 +22,14 @@ public class HoldingsController {
     private final HoldingsService holdingsService;
     private final RealTimeStockService realTimeStockService;
 
-    @Operation(summary = "장 마감 후 계좌 보유 종목 data 조회",description = "DB에서 데이터를 불러오는 API")
+    @Operation(summary = "장 마감 후 계좌 보유 종목 data 조회", description = "DB에서 데이터를 불러오는 API")
     @GetMapping(value = "/{id}")
     public ApiResponse<List<HoldingsDto>> getHoldings(@PathVariable int id) {
         List<HoldingsDto> holdingsList = holdingsService.getHoldings(id);
         return new ApiResponse<>(200, true, "보유종목을 조회했습니다.", holdingsList);
     }
 
-    @Operation(summary = "실시간 계좌 보유 종목 data 조회",description = "실시간 데이터를 불러오는 API")
+    @Operation(summary = "실시간 계좌 보유 종목 data 조회", description = "실시간 데이터를 불러오는 API")
     @GetMapping(value = "/realtime/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<HoldingsDto> getRealTimeHoldings(@PathVariable int id) {
         return holdingsService.getRealTimeHoldings(id, realTimeStockService.getDataOnlyStream());

--- a/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsService.java
+++ b/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsService.java
@@ -2,14 +2,24 @@ package com.example.stock_system.holdings;
 
 import com.example.stock_system.account.Account;
 import com.example.stock_system.account.AccountRepository;
+import com.example.stock_system.account.TeamAccount;
+import com.example.stock_system.account.TeamAccountRepository;
 import com.example.stock_system.account.exception.AccountErrorCode;
 import com.example.stock_system.account.exception.AccountException;
+import com.example.stock_system.enums.TradeStatus;
+import com.example.stock_system.enums.TradeType;
 import com.example.stock_system.holdings.dto.HoldingsDto;
 import com.example.stock_system.holdings.dto.SaveClosingPrice;
 import com.example.stock_system.holdings.exception.HoldingsErrorCode;
 import com.example.stock_system.holdings.exception.HoldingsException;
+import com.example.stock_system.stocks.Stocks;
+import com.example.stock_system.stocks.StocksRepository;
 import com.example.stock_system.stocks.StocksService;
 import com.example.stock_system.stocks.dto.StockCurrentPrice;
+import com.example.stock_system.stocks.exception.StocksErrorCode;
+import com.example.stock_system.stocks.exception.StocksException;
+import com.example.stock_system.trade.Trade;
+import com.example.stock_system.trade.TradeRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -25,6 +35,9 @@ public class HoldingsService {
     private final HoldingsRepository holdingsRepository;
     private final AccountRepository accountRepository;
     private final StocksService stocksService;
+    private final TeamAccountRepository teamAccountRepository;
+    private final StocksRepository stocksRepository;
+    private final TradeRepository tradeRepository;
 
     public List<HoldingsDto> getHoldings(int accountId) {
         Account account = accountRepository.findById(accountId).orElseThrow(() -> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
@@ -77,4 +90,30 @@ public class HoldingsService {
 
     }
 
+    public Integer getNumOfHoldings(int teamId, String code) {
+        TeamAccount teamAccount = teamAccountRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+
+        Account account = teamAccount.getAccount();
+        Stocks stocks = stocksRepository.findByCode(code)
+                .orElseThrow(() -> new StocksException(StocksErrorCode.STOCKS_NOT_FOUND));
+        Holdings holdings = holdingsRepository.findByAccountAndStockCode(account, stocks)
+                .orElseThrow(() -> new HoldingsException(HoldingsErrorCode.HOLDINGS_NOT_FOUND));
+
+        return holdings.getHldgQty();
+    }
+
+    public Integer getAvailableAsset(int teamId) {
+        TeamAccount teamAccount = teamAccountRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+
+        Account account = teamAccount.getAccount();
+
+        List<Trade> trades = tradeRepository.findAllByAccountAndTypeAndStatus(account, TradeType.BUY, TradeStatus.PENDING)
+                .orElseGet(() -> List.of());
+
+        int pendingBuyAmount = trades.stream().mapToInt(trade -> trade.getPrice() * trade.getQuantity()).sum();
+
+        return account.getDeposit() - pendingBuyAmount;
+    }
 }

--- a/stock-system/src/main/java/com/example/stock_system/trade/TradeRepository.java
+++ b/stock-system/src/main/java/com/example/stock_system/trade/TradeRepository.java
@@ -15,4 +15,7 @@ public interface TradeRepository extends JpaRepository<Trade, Integer> {
     Optional<List<Trade>> findAllByAccountAndStockCodeAndTypeAndStatus(Account account, Stocks stockCode, TradeType type, TradeStatus status);
 
     List<Trade> findByStatusAndStockCodeAndPriceAndType(TradeStatus status, Stocks stockCode, int price, TradeType type);
+
+    Optional<List<Trade>> findAllByAccountAndTypeAndStatus(Account account, TradeType tradeType, TradeStatus tradeStatus);
+
 }

--- a/stock-system/src/main/java/com/example/stock_system/trade/TradeService.java
+++ b/stock-system/src/main/java/com/example/stock_system/trade/TradeService.java
@@ -11,25 +11,31 @@ import com.example.stock_system.enums.TradeStatus;
 import com.example.stock_system.enums.TradeType;
 import com.example.stock_system.holdings.Holdings;
 import com.example.stock_system.holdings.HoldingsRepository;
+import com.example.stock_system.holdings.dto.ToAlarmDto;
 import com.example.stock_system.holdings.exception.HoldingsErrorCode;
 import com.example.stock_system.holdings.exception.HoldingsException;
-import com.example.stock_system.holdings.dto.ToAlarmDto;
 import com.example.stock_system.rabbitMq.MqSender;
 import com.example.stock_system.stocks.Stocks;
 import com.example.stock_system.stocks.StocksRepository;
 import com.example.stock_system.stocks.exception.StocksErrorCode;
 import com.example.stock_system.stocks.exception.StocksException;
 import com.example.stock_system.trade.dto.CreateTradeRequest;
+import com.example.stock_system.trade.dto.GetAllTradesResponse;
 import com.example.stock_system.trade.dto.TradeDto;
+import com.example.stock_system.trade.dto.TradeResponse;
 import com.example.stock_system.trade.exception.TradeException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
@@ -37,7 +43,7 @@ import java.util.List;
 
 @Slf4j
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TradeService {
     private final AccountRepository accountRepository;
     private final StocksRepository stocksRepository;
@@ -183,6 +189,25 @@ public class TradeService {
             System.out.println("매도 완료 - 주식 코드: " + stockCode + ", 거래 ID: " + trade.getId());
         }
 
+    }
+
+    public Integer getNumOfSellingTrades(int teamId, String code) {
+        TeamAccount teamAccount = teamAccountRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new AccountException(AccountErrorCode.TEAM_ACCOUNT_NOT_FOUND));
+
+        Account account = teamAccount.getAccount();
+        Stocks stocks = stocksRepository.findByCode(code)
+                .orElseThrow(() -> new StocksException(StocksErrorCode.STOCKS_NOT_FOUND));
+
+        List<Trade> trades = tradeRepository.findAllByAccountAndStockCodeAndTypeAndStatus(account, stocks, TradeType.SELL, TradeStatus.PENDING)
+                .orElseGet(Collections::emptyList);
+
+        int tradeQuantity = 0;
+        for (Trade trade : trades) {
+            tradeQuantity += trade.getQuantity();
+        }
+
+        return tradeQuantity;
     }
 
 }

--- a/stock-system/src/main/java/com/example/stock_system/trade/dto/GetAllTradesResponse.java
+++ b/stock-system/src/main/java/com/example/stock_system/trade/dto/GetAllTradesResponse.java
@@ -1,0 +1,19 @@
+package com.example.stock_system.trade.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GetAllTradesResponse {
+    private List<TradeResponse> trades;
+
+    public GetAllTradesResponse() {
+    }
+
+    @Builder
+    public GetAllTradesResponse(List<TradeResponse> trades) {
+        this.trades = trades;
+    }
+}

--- a/stock-system/src/main/java/com/example/stock_system/trade/dto/TradeResponse.java
+++ b/stock-system/src/main/java/com/example/stock_system/trade/dto/TradeResponse.java
@@ -1,0 +1,25 @@
+package com.example.stock_system.trade.dto;
+
+import com.example.stock_system.enums.TradeType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TradeResponse {
+    private String stockName;
+    private TradeType type;
+    private int price;
+    private int quantity;
+    private LocalDateTime tradeDate;
+
+    @Builder
+    public TradeResponse(String stockName, TradeType type, int price, int quantity, LocalDateTime tradeDate) {
+        this.stockName = stockName;
+        this.type = type;
+        this.price = price;
+        this.quantity = quantity;
+        this.tradeDate = tradeDate;
+    }
+}

--- a/stock-system/src/main/resources/application.yml
+++ b/stock-system/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
       ddl-auto: none
     show-sql: false
 
-
   rabbitmq:
     host: ${MQ_HOST}
     port: ${MQ_PORT}
@@ -33,9 +32,6 @@ spring:
       name: stock_to_alarm
     mainToStock:
       name: offer_to_trade
-
-  jwt:
-    secret: ${JWT_SECRET}
 
 server:
   port: 8082


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 매매 제안 시, 발생할 수 있는 예외를 추가했습니다.
- userId, teamId를 헤더의 토큰으로 받아올 수 있게 수정했습니다.

### 테스트 결과
- 가지고 있는 돈보다 더 많이 매수하고자 하는 제안을 할 때 자산 부족 예외 발생
<img width="790" alt="image" src="https://github.com/user-attachments/assets/c5b9f433-c139-4321-a6cf-0bc52bdb7b72">

- 가지고 있는 보유 수량보다 더 많이 매도하고자 하는 제안을 할 때 보유 수량 부족 예외 발생
<img width="784" alt="image" src="https://github.com/user-attachments/assets/f43aa962-7001-466c-bf4c-38fd6b90909e">