### PR TITLE
pending 상태 팀 초대코드 조회, 유저가 속한 팀 정보 조회 api에 ( 카테고리, 이름) 추가

### DIFF
--- a/group-investment/src/main/java/com/example/group_investment/member/dto/MemberDto.java
+++ b/group-investment/src/main/java/com/example/group_investment/member/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.example.group_investment.member.dto;
 
+import com.example.group_investment.enums.JoinStatus;
 import com.example.group_investment.enums.MemberRole;
 import com.example.group_investment.member.Member;
 import com.example.group_investment.team.Team;
@@ -12,13 +13,15 @@ public class MemberDto {
     private User user;
     private Team team;
     private MemberRole role;
+    private JoinStatus joinStatus;
     private LocalDateTime createdAt;
 
     @Builder
-    public MemberDto(User user, Team team, MemberRole role, LocalDateTime createdAt) {
+    public MemberDto(User user, Team team, MemberRole role, JoinStatus joinstatus, LocalDateTime createdAt) {
         this.user = user;
         this.team = team;
         this.role = role;
+        this.joinStatus = joinstatus;
         this.createdAt = createdAt;
     }
 
@@ -27,6 +30,7 @@ public class MemberDto {
                 .user(this.user)
                 .team(this.team)
                 .role(this.role)
+                .joinStatus(this.joinStatus)
                 .createdAt(this.createdAt)
                 .build();
     }

--- a/group-investment/src/main/java/com/example/group_investment/team/InvitationRepository.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/InvitationRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface InvitationRepository extends JpaRepository<Invitation, Integer> {
     Optional<Invitation> findByInviteCode(String inviteCode);
 
-    Invitation findByTeam(Team team);
+    Optional<Invitation> findByTeam(Team team);
 }

--- a/group-investment/src/main/java/com/example/group_investment/team/InvitationRepository.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/InvitationRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Repository
 public interface InvitationRepository extends JpaRepository<Invitation, Integer> {
     Optional<Invitation> findByInviteCode(String inviteCode);
+
+    Invitation findByTeam(Team team);
 }

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamController.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamController.java
@@ -20,7 +20,7 @@ public class TeamController {
 
     // TeamResponseDto를 만들어서 response해주세요.
     // ApiResponse를 사용해서 response 형식을 통일해주세요.
-    @Operation(summary = "유저가 속한 팀들의 pk와 status를 조회하는 API")
+    @Operation(summary = "유저가 속한 팀들의 pk와 status, 이름, 카테고리를 조회하는 API(")
     @GetMapping("/users")
     public ApiResponse<List<TeamByUserResponse>> selectTeamByUser(@RequestAttribute("userId") int userId) {
         List<TeamByUserResponse> teamByUserResponse = teamService.selectTeamByUser(userId);

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamController.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamController.java
@@ -50,9 +50,9 @@ public class TeamController {
     }
 
     @Operation(summary = "PENDING 상태 팀을 조회하는 API")
-    @GetMapping("/pending")
-    public ApiResponse<DetailPendingTeamResponse> selectDetails(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId) {
-        DetailPendingTeamResponse detailPendingTeamResponse = teamService.selectPendingDetails(userId, teamId);
+    @GetMapping("/{id}/pending")
+    public ApiResponse<DetailPendingTeamResponse> selectDetails(@RequestAttribute("userId") int userId, @PathVariable int id) {
+        DetailPendingTeamResponse detailPendingTeamResponse = teamService.selectPendingDetails(userId, id);
         return new ApiResponse<>(200, true, "초대를 받은 팀 정보를 조회했습니다.", detailPendingTeamResponse);
     }
 

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -162,7 +162,7 @@ public class TeamService {
         int invitedMembers = memberRepository.countByTeam(team).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         //2-6. 팀의 초대 코드 조회
-        Invitation invitation = invitationRepository.findByTeam(team);
+        Invitation invitation = invitationRepository.findByTeam(team).orElseThrow(() -> new TeamException(TeamErrorCode.INVITATION_NOT_FOUND));
         String invitedCode = invitation.getInviteCode();
 
         return DetailPendingTeamResponse.builder()

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -64,6 +64,7 @@ public class TeamService {
                 .category(createTeamRequest.getCategory())
                 .startAt(createTeamRequest.getStartAt())
                 .endAt(createTeamRequest.getEndAt())
+                .status(TeamStatus.PENDING)
                 .build();
         try {
             savedTeam = teamRepository.save(teamDto.toEntity());
@@ -156,9 +157,12 @@ public class TeamService {
             }
         }
         //2-5. 인원수 조회
-        // FIXME : 멤버
         int invitedMembers = memberRepository.countByTeam(team).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
+        //2-6. 팀의 초대 코드 조회
+        Invitation invitation = invitationRepository.findByTeam(team);
+        String invitedCode = invitation.getInviteCode();
+        
         return DetailPendingTeamResponse.builder()
                 .name(teamDto.getName())
                 .baseAmt(teamDto.getBaseAmt())
@@ -177,6 +181,7 @@ public class TeamService {
                 .invitedMembers(invitedMembers)
                 .isLeader(isLeader)
                 .isParticipating(isParticipating)
+                .invitedCode(invitedCode)
                 .build();
     }
 

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -22,6 +22,7 @@ import com.example.group_investment.user.UserRepository;
 import com.example.group_investment.user.exception.UserErrorCode;
 import com.example.group_investment.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.mapping.Join;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -93,6 +94,7 @@ public class TeamService {
                 .team(savedTeam)
                 .user(user)
                 .role(MemberRole.LEADER)
+                .joinstatus(JoinStatus.ACTIVE)
                 .build();
         try {
             memberRepository.save(memberDto.toEntity());
@@ -162,7 +164,7 @@ public class TeamService {
         //2-6. 팀의 초대 코드 조회
         Invitation invitation = invitationRepository.findByTeam(team);
         String invitedCode = invitation.getInviteCode();
-        
+
         return DetailPendingTeamResponse.builder()
                 .name(teamDto.getName())
                 .baseAmt(teamDto.getBaseAmt())
@@ -192,6 +194,7 @@ public class TeamService {
                 .team(team)
                 .user(user)
                 .role(MemberRole.MEMBER)
+                .joinstatus(JoinStatus.ACTIVE)
                 .build();
         try {
             memberRepository.save(memberDto.toEntity());

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -237,7 +237,8 @@ public class TeamService {
         List<Member> members = memberRepository.findByUser(user).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
         List<TeamByUserResponse> teamByUserResponses = new ArrayList<>();
         for (Member member : members) {
-            teamByUserResponses.add(new TeamByUserResponse(member.getTeam().getId(), member.getTeam().getStatus()));
+            if (member.getJoinStatus() == JoinStatus.ACTIVE)
+                teamByUserResponses.add(new TeamByUserResponse(member.getTeam().getId(), member.getTeam().getStatus(), member.getTeam().getName(),member.getTeam().getCategory()));
         }
         return teamByUserResponses;
     }

--- a/group-investment/src/main/java/com/example/group_investment/team/dto/DetailPendingTeamResponse.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/dto/DetailPendingTeamResponse.java
@@ -30,8 +30,10 @@ public class DetailPendingTeamResponse {
     private int isLeader;
     private int isParticipating;
 
+    private String invitedCode;
+
     @Builder
-    public DetailPendingTeamResponse(String name, int baseAmt, int headCount, Category category, LocalDateTime startAt, LocalDateTime endAt, double prdyVrssRt, int urgentTradeUpvotes, int tradeUpvotes, int depositAmt, RulePeriod period, LocalDate payDate, double maxLossRt, double maxProfitRt, int invitedMembers, int isLeader, int isParticipating) {
+    public DetailPendingTeamResponse(String name, int baseAmt, int headCount, Category category, LocalDateTime startAt, LocalDateTime endAt, double prdyVrssRt, int urgentTradeUpvotes, int tradeUpvotes, int depositAmt, RulePeriod period, LocalDate payDate, double maxLossRt, double maxProfitRt, int invitedMembers, int isLeader, int isParticipating, String invitedCode) {
         this.name = name;
         this.baseAmt = baseAmt;
         this.headCount = headCount;
@@ -49,6 +51,7 @@ public class DetailPendingTeamResponse {
         this.invitedMembers = invitedMembers;
         this.isLeader = isLeader;
         this.isParticipating = isParticipating;
+        this.invitedCode = invitedCode;
     }
 
     public DetailPendingTeamResponse() {

--- a/group-investment/src/main/java/com/example/group_investment/team/dto/TeamByUserResponse.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/dto/TeamByUserResponse.java
@@ -1,5 +1,6 @@
 package com.example.group_investment.team.dto;
 
+import com.example.group_investment.enums.Category;
 import com.example.group_investment.enums.TeamStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,11 +9,15 @@ import lombok.Getter;
 public class TeamByUserResponse {
     private int teamId;
     private TeamStatus status;
+    private String name;
+    private Category category;
 
     @Builder
-    public TeamByUserResponse(int teamId, TeamStatus status) {
+    public TeamByUserResponse(int teamId, TeamStatus status, String name, Category category) {
         this.teamId = teamId;
         this.status = status;
+        this.name = name;
+        this.category = category;
     }
 
     public TeamByUserResponse() {


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. pending 상태 팀 조회시 초대코드 추가했습니다. 
1-1. 팀 생성시 status - 디폴트로 pending 처리 안돼서 null로 올라간걸 PENDING되게끔 코드 수정  
1-2. 테스트 해야해서 api 경로 변경 했습니다 : requestAttribute -> pathVariable team_id 받음 
--
2. 유저가 속한 팀 조회시 joinstatus (drop or done) 제외하고 active 일경우만 팀 정보 조회하도록 수정 
2-1. 팀을 참가할때 생성할때 member - joinstatus에 ACTIVE되게 수정

### 테스트 결과
1. 팀 생성시 pending 되게 함
![image](https://github.com/user-attachments/assets/d8ae53fb-9f1f-43d5-9d69-d6b3af017aa9)

2. pending 상태 팀 조회 시 초대코드도 같이 줌  
![image](https://github.com/user-attachments/assets/e0898197-c255-4e54-9314-fe149da67ece)

--
3. 유저가 속한 팀 조회 : 해당 유저는 다른 모임에도 가입 되어있지만 두개 팀을 제외하고 JoinStatus가 null임 
![image](https://github.com/user-attachments/assets/3f1df685-f68f-49e5-8a0f-7b33ebcea053)
![image](https://github.com/user-attachments/assets/e106b14e-7903-42dc-821d-e81e78da69f4)

