### PR TITLE
대시보드 정보 조회 api 생성(주요 증권 뉴스 Top5, 코스피/코스닥 지수)

### DIFF
--- a/invest-references/build.gradle
+++ b/invest-references/build.gradle
@@ -3,11 +3,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web:3.3.3'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.3.3'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
     compileOnly 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation project(':common')
+    implementation 'org.jsoup:jsoup:1.14.3'
 
+    implementation project(':common')
 }

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
@@ -1,11 +1,22 @@
 package com.example.invest_references;
 
+import com.example.common.dto.ApiResponse;
+import com.example.invest_references.dto.News;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @AllArgsConstructor
 public class InvestRefController {
     private final InvestRefService investRefService;
 
+    @Operation(summary = "주요 뉴스 조회", description = "네이버 증권에서 주요 뉴스 5개를 가져옵니다.")
+    @GetMapping("/api/news")
+    public ApiResponse<List<News>> getNews() {
+        return new ApiResponse<>(200, true, "주요 뉴스를 가져왔습니다.", investRefService.getNews());
+    }
 }

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
@@ -1,6 +1,7 @@
 package com.example.invest_references;
 
 import com.example.common.dto.ApiResponse;
+import com.example.invest_references.dto.MarketIndexResponse;
 import com.example.invest_references.dto.News;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
@@ -18,5 +19,11 @@ public class InvestRefController {
     @GetMapping("/api/news")
     public ApiResponse<List<News>> getNews() {
         return new ApiResponse<>(200, true, "주요 뉴스를 가져왔습니다.", investRefService.getNews());
+    }
+
+    @Operation(summary = "코스피/코스닥 지수 조회", description = "네이버 증권에서 코스피/코스닥 지수를 가져옵니다.")
+    @GetMapping("/api/market-index")
+    public ApiResponse<MarketIndexResponse> getMarketIndex() {
+        return new ApiResponse<>(200, true, "코스피/코스닥 지수를 가져왔습니다.", investRefService.getMarketIndex());
     }
 }

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
@@ -1,0 +1,11 @@
+package com.example.invest_references;
+
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class InvestRefController {
+    private final InvestRefService investRefService;
+
+}

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
@@ -1,5 +1,8 @@
 package com.example.invest_references;
 
+import com.example.invest_references.dto.Kosdaq;
+import com.example.invest_references.dto.Kospi;
+import com.example.invest_references.dto.MarketIndexResponse;
 import com.example.invest_references.dto.News;
 import com.example.invest_references.exception.InvestRefErrorCode;
 import com.example.invest_references.exception.InvestRefException;
@@ -20,18 +23,17 @@ public class InvestRefService {
 
     private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
     private static final String NAVER_FINANCE_NEWS_URL = "https://finance.naver.com/news/mainnews.naver";
+    private static final String NAVER_FINANCE_MARKET_INDEX_URL = "https://finance.naver.com/sise/sise_index.naver?code=";
 
     // 네이버 증권 주요 뉴스를 가져오는 메서드
     public List<News> getNews() {
         List<News> newsList = new ArrayList<>();
 
         try {
-            // Jsoup을 사용해 네이버 증권 뉴스 페이지의 HTML 가져오기
             Document doc = Jsoup.connect(NAVER_FINANCE_NEWS_URL)
                     .userAgent(USER_AGENT)
                     .get();
 
-            // 뉴스 리스트를 가져오는 selector (사진에서 제공된 HTML 구조 기반)
             Elements newsElements = doc.select("ul.newsList > li.block1");
 
             // 상위 5개의 뉴스만 파싱
@@ -44,14 +46,53 @@ public class InvestRefService {
                 String url = "https://finance.naver.com" + newsElement.select("a").attr("href");  // 뉴스 URL
                 String date = newsElement.select(".wdate").text().trim();   // 날짜
 
-                // 뉴스 DTO에 저장
-                News newsDTO = new News(press, title, url, date);
-                newsList.add(newsDTO);
+                News news = new News(press, title, url, date);
+                newsList.add(news);
             }
         } catch (IOException e) {
             throw new InvestRefException(InvestRefErrorCode.FAILED_TO_GET_NEWS);
         }
 
         return newsList;
+    }
+
+    public MarketIndexResponse getMarketIndex() {
+        try {
+            Document kospiDoc = Jsoup.connect(NAVER_FINANCE_MARKET_INDEX_URL + "KOSPI")
+                    .userAgent(USER_AGENT)
+                    .get();
+
+            System.out.println("kospiDoc = " + kospiDoc.title());
+
+            String kospiNowValue = kospiDoc.select("em#now_value").text().trim();
+            String kospiChangeValueAndRate = kospiDoc.select("span#change_value_and_rate").text().trim();
+            String kospiChangeValue = kospiChangeValueAndRate.split(" ")[0];
+            String kospiChangeRate = kospiChangeValueAndRate.split(" ")[1].replaceAll("[^0-9-.%]", "");
+
+            Document kosdaqDoc = Jsoup.connect(NAVER_FINANCE_MARKET_INDEX_URL + "KOSDAQ")
+                    .userAgent(USER_AGENT)
+                    .get();
+
+            String kosdaqNowValue = kosdaqDoc.select("em#now_value").text().trim();
+            String kosdaqChangeValueAndRate = kosdaqDoc.select("span#change_value_and_rate").text().trim();
+            String kosdaqChangeValue = kosdaqChangeValueAndRate.split(" ")[0];
+            String kosdaqChangeRate = kosdaqChangeValueAndRate.split(" ")[1].replaceAll("[^0-9-.%]", "");
+
+            return MarketIndexResponse.builder()
+                    .kospi(Kospi.builder()
+                            .currentValue(kospiNowValue)
+                            .changeValue(kospiChangeValue)
+                            .changeRate(kospiChangeRate)
+                            .build())
+                    .kosdaq(Kosdaq.builder()
+                            .currentValue(kosdaqNowValue)
+                            .changeValue(kosdaqChangeValue)
+                            .changeRate(kosdaqChangeRate)
+                            .build())
+                    .build();
+
+        } catch (IOException e) {
+            throw new InvestRefException(InvestRefErrorCode.FAILED_TO_GET_MARKET_INDEX);
+        }
     }
 }

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
@@ -1,10 +1,57 @@
 package com.example.invest_references;
 
+import com.example.invest_references.dto.News;
+import com.example.invest_references.exception.InvestRefErrorCode;
+import com.example.invest_references.exception.InvestRefException;
 import lombok.AllArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @AllArgsConstructor
 public class InvestRefService {
 
+    private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
+    private static final String NAVER_FINANCE_NEWS_URL = "https://finance.naver.com/news/mainnews.naver";
+
+    // 네이버 증권 주요 뉴스를 가져오는 메서드
+    public List<News> getNews() {
+        List<News> newsList = new ArrayList<>();
+
+        try {
+            // Jsoup을 사용해 네이버 증권 뉴스 페이지의 HTML 가져오기
+            Document doc = Jsoup.connect(NAVER_FINANCE_NEWS_URL)
+                    .userAgent(USER_AGENT)
+                    .get();
+
+            // 뉴스 리스트를 가져오는 selector (사진에서 제공된 HTML 구조 기반)
+            Elements newsElements = doc.select("ul.newsList > li.block1");
+
+            // 상위 5개의 뉴스만 파싱
+            for (int i = 0; i < Math.min(5, newsElements.size()); i++) {
+                Element newsElement = newsElements.get(i);
+
+                // 각 뉴스의 정보 추출
+                String press = newsElement.select(".press").text().trim();  // 언론사
+                String title = newsElement.select("a").text().trim();      // 뉴스 제목
+                String url = "https://finance.naver.com" + newsElement.select("a").attr("href");  // 뉴스 URL
+                String date = newsElement.select(".wdate").text().trim();   // 날짜
+
+                // 뉴스 DTO에 저장
+                News newsDTO = new News(press, title, url, date);
+                newsList.add(newsDTO);
+            }
+        } catch (IOException e) {
+            throw new InvestRefException(InvestRefErrorCode.FAILED_TO_GET_NEWS);
+        }
+
+        return newsList;
+    }
 }

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
@@ -1,0 +1,10 @@
+package com.example.invest_references;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class InvestRefService {
+
+}

--- a/invest-references/src/main/java/com/example/invest_references/dto/Kosdaq.java
+++ b/invest-references/src/main/java/com/example/invest_references/dto/Kosdaq.java
@@ -1,0 +1,18 @@
+package com.example.invest_references.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Kosdaq {
+    private final String currentValue;
+    private final String changeValue;
+    private final String changeRate;
+
+    @Builder
+    public Kosdaq(String currentValue, String changeValue, String changeRate) {
+        this.currentValue = currentValue;
+        this.changeValue = changeValue;
+        this.changeRate = changeRate;
+    }
+}

--- a/invest-references/src/main/java/com/example/invest_references/dto/Kospi.java
+++ b/invest-references/src/main/java/com/example/invest_references/dto/Kospi.java
@@ -1,0 +1,18 @@
+package com.example.invest_references.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Kospi {
+    private final String currentValue;
+    private final String changeValue;
+    private final String changeRate;
+
+    @Builder
+    public Kospi(String currentValue, String changeValue, String changeRate) {
+        this.currentValue = currentValue;
+        this.changeValue = changeValue;
+        this.changeRate = changeRate;
+    }
+}

--- a/invest-references/src/main/java/com/example/invest_references/dto/MarketIndexResponse.java
+++ b/invest-references/src/main/java/com/example/invest_references/dto/MarketIndexResponse.java
@@ -1,0 +1,16 @@
+package com.example.invest_references.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MarketIndexResponse {
+    private final Kospi kospi;
+    private final Kosdaq kosdaq;
+
+    @Builder
+    public MarketIndexResponse(Kospi kospi, Kosdaq kosdaq) {
+        this.kospi = kospi;
+        this.kosdaq = kosdaq;
+    }
+}

--- a/invest-references/src/main/java/com/example/invest_references/dto/News.java
+++ b/invest-references/src/main/java/com/example/invest_references/dto/News.java
@@ -1,0 +1,20 @@
+package com.example.invest_references.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class News {
+    private String press;
+    private String title;
+    private String url;
+    private String date;
+
+    @Builder
+    public News(String press, String title, String url, String date) {
+        this.press = press;
+        this.title = title;
+        this.url = url;
+        this.date = date;
+    }
+}

--- a/invest-references/src/main/java/com/example/invest_references/exception/InvestRefErrorCode.java
+++ b/invest-references/src/main/java/com/example/invest_references/exception/InvestRefErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.invest_references.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum InvestRefErrorCode {
+    FAILED_TO_GET_NEWS(400, "AG001", "네이버 증권 뉴스를 가져오는 데 실패했습니다."),
+    ;
+
+    private final int status;
+    private final String divisionCode;
+    private final String message;
+
+    InvestRefErrorCode(int status, String divisionCode, String message) {
+        this.status = status;
+        this.divisionCode = divisionCode;
+        this.message = message;
+    }
+}

--- a/invest-references/src/main/java/com/example/invest_references/exception/InvestRefErrorCode.java
+++ b/invest-references/src/main/java/com/example/invest_references/exception/InvestRefErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum InvestRefErrorCode {
     FAILED_TO_GET_NEWS(400, "AG001", "네이버 증권 뉴스를 가져오는 데 실패했습니다."),
-    ;
+    FAILED_TO_GET_MARKET_INDEX(400, "AG002", "코스피/코스닥 지수를 가져오는 데 실패했습니다.");
 
     private final int status;
     private final String divisionCode;

--- a/invest-references/src/main/java/com/example/invest_references/exception/InvestRefException.java
+++ b/invest-references/src/main/java/com/example/invest_references/exception/InvestRefException.java
@@ -1,0 +1,14 @@
+package com.example.invest_references.exception;
+
+import com.example.common.exception.ErrorCode;
+import com.example.common.exception.GlobalException;
+
+public class InvestRefException extends GlobalException {
+    public InvestRefException(InvestRefErrorCode errorCode) {
+        super(errorCode.getMessage(), null, errorCode.getStatus(), errorCode.getDivisionCode());
+    }
+
+    public InvestRefException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), null, errorCode.getStatus(), errorCode.getDivisionCode());
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 대시보드에 띄울 뉴스를 조회합니다.
`/api/news`
- 대시보드에 띄울 코스피/코스닥 지수를 조회합니다.
`/api/market-index`

### 테스트 결과
- 최근 뉴스 5개를 조회합니다.
<img width="786" alt="image" src="https://github.com/user-attachments/assets/73a05297-48b6-4b8d-92a2-115de112708a">

- 코스피/코스닥 지수 정보를 조회합니다.
<img width="782" alt="image" src="https://github.com/user-attachments/assets/3918f346-cb19-4e7e-b5f5-96aaf00479c0">
