### PR TITLE
회원가입, 내정보수정, jwt 토큰업데이트

### DIFF
--- a/ag-gateway/src/main/java/com/example/ag_gateway/authorization/JwtFilter.java
+++ b/ag-gateway/src/main/java/com/example/ag_gateway/authorization/JwtFilter.java
@@ -33,7 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 요청 URL을 가져와서 제외할 URL 목록과 비교
         String requestURI = request.getRequestURI();
-        log.info("[requestURI] {}", requestURI);
+        log.info("[GATEWAY]-jwtFilter : [requestURI] {}", requestURI);
 
         // login/sign up에 대해서는 필터링을 수행하지 않음
         if (excludeUrls.stream().anyMatch(requestURI::startsWith)) {
@@ -70,6 +70,7 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
+        log.info("토큰 검증이 완료되었습니다.");
         filterChain.doFilter(request, response);
     }
 }

--- a/ag-gateway/src/main/java/com/example/ag_gateway/config/SecurityConfig.java
+++ b/ag-gateway/src/main/java/com/example/ag_gateway/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.example.ag_gateway.config;
 
 import com.example.ag_gateway.authorization.JwtFilter;
 import com.example.ag_gateway.authorization.JwtUtil;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -12,7 +11,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -59,7 +57,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests((requests) -> requests
-                                .anyRequest().permitAll())
+                        .anyRequest().permitAll())
                 .addFilterBefore(new JwtFilter(jwtUtil), BasicAuthenticationFilter.class)
         ;
 
@@ -69,5 +67,4 @@ public class SecurityConfig {
 
         return http.build();
     }
-
 }

--- a/common/src/main/java/com/example/common/config/WebConfig.java
+++ b/common/src/main/java/com/example/common/config/WebConfig.java
@@ -16,23 +16,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final JwtUtil jwtUtil;
 
-    @Value("${spring.ag.url}")
-    private String gatewayUrl;
-
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor(jwtUtil));
-    }
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry){
-        registry.addMapping("/**")
-                .allowedOriginPatterns(gatewayUrl)
-                .allowedHeaders("*")
-                .allowedMethods("*")
-                .allowCredentials(true)
-                .allowedHeaders("*")
-                .exposedHeaders("Authorization");
     }
 
     @Override

--- a/group-investment/src/main/java/com/example/group_investment/auth/AgUserDetailsService.java
+++ b/group-investment/src/main/java/com/example/group_investment/auth/AgUserDetailsService.java
@@ -38,4 +38,12 @@ public class AgUserDetailsService implements UserDetailsService {
         User user = userRepository.findById(id).orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
         return user.getMembers().get(0).getTeam().getId();
     }
+
+    public boolean isUserActive(String loginId) {
+        User user = userRepository.findByLoginId(loginId).orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
+        if (!user.isActive()) {
+            throw new UserException(UserErrorCode.USER_NOT_ACTIVE);
+        }
+        return true;
+    }
 }

--- a/group-investment/src/main/java/com/example/group_investment/auth/AuthController.java
+++ b/group-investment/src/main/java/com/example/group_investment/auth/AuthController.java
@@ -2,6 +2,7 @@ package com.example.group_investment.auth;
 
 import com.example.common.auth.JwtUtil;
 import com.example.common.dto.ApiResponse;
+import com.example.group_investment.auth.exception.AuthoException;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
@@ -38,5 +39,4 @@ public class AuthController {
                 headers,
                 HttpStatus.OK);
     }
-
 }

--- a/group-investment/src/main/java/com/example/group_investment/auth/filter/LoginFilter.java
+++ b/group-investment/src/main/java/com/example/group_investment/auth/filter/LoginFilter.java
@@ -5,6 +5,7 @@ import com.example.group_investment.auth.AgUserDetails;
 import com.example.group_investment.auth.AgUserDetailsService;
 import com.example.group_investment.auth.exception.AuthoErrorCode;
 import com.example.group_investment.auth.exception.AuthoException;
+import com.example.group_investment.user.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,13 +41,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String password;
 
         try {
-            log.info("[LoginFilter의 attemptAuthentication] "+ request.getContentType());
+            log.info("[LoginFilter에서 로그인 시도] "+ request.getContentType());
             if (request.getContentType().startsWith("application/json")) {
                 // JSON 데이터 파싱
                 System.out.println("application/json");
                 Map<String, String> requestBody = new ObjectMapper().readValue(request.getInputStream(), Map.class);
                 username = requestBody.get("loginId");
                 password = requestBody.get("password");
+                userDetailsService.isUserActive(username);
             } else {
                 // x-www-form-urlencoded 방식의 폼 데이터 처리
                 username = obtainUsername(request);

--- a/group-investment/src/main/java/com/example/group_investment/backend_only/BackendController.java
+++ b/group-investment/src/main/java/com/example/group_investment/backend_only/BackendController.java
@@ -27,7 +27,7 @@ public class BackendController {
     @Operation(summary = "멤버 방출",description = "돈을 안낸 멤버를 방출한다.")
     @PostMapping("/expelMember")
     public ApiResponse expelMember(@RequestBody List<PayFail> payFails){
-        teamService.expelMember(payFails);
+        teamService.cancelMember(payFails);
         return new ApiResponse<>(200,true,"완료",null);
     }
 

--- a/group-investment/src/main/java/com/example/group_investment/enums/JoinStatus.java
+++ b/group-investment/src/main/java/com/example/group_investment/enums/JoinStatus.java
@@ -7,7 +7,8 @@ public enum JoinStatus {
 
     ACTIVE("참가 중"),
     DONE("완료"),
-    DROP("도중 탈퇴");
+    DROP("도중 탈퇴"),
+    CANCEL("팀 폭파");
 
     private final String message;
 

--- a/group-investment/src/main/java/com/example/group_investment/enums/TeamStatus.java
+++ b/group-investment/src/main/java/com/example/group_investment/enums/TeamStatus.java
@@ -3,5 +3,6 @@ package com.example.group_investment.enums;
 public enum TeamStatus {
     PENDING,
     ACTIVE,
-    FINISHED
+    FINISHED,
+    CANCEL, // pending 상태에서 팀 폭파
 }

--- a/group-investment/src/main/java/com/example/group_investment/enums/UserStatus.java
+++ b/group-investment/src/main/java/com/example/group_investment/enums/UserStatus.java
@@ -1,0 +1,6 @@
+package com.example.group_investment.enums;
+
+
+public enum UserStatus {
+    ACTIVE, INACTIVE
+}

--- a/group-investment/src/main/java/com/example/group_investment/member/Member.java
+++ b/group-investment/src/main/java/com/example/group_investment/member/Member.java
@@ -75,6 +75,11 @@ public class Member {
         this.dropedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 
+    public void cancelMember(){
+        this.joinStatus = JoinStatus.CANCEL;
+        this.dropedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
     public Member() {
 
     }

--- a/group-investment/src/main/java/com/example/group_investment/rule/exception/RuleErrorCode.java
+++ b/group-investment/src/main/java/com/example/group_investment/rule/exception/RuleErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum RuleErrorCode {
     RULE_NOT_FOUND(404, "AG401", "규칙이 존재하지 않습니다."),
     RULE_SAVE_FAILED(400, "AG001", "규칙 생성에 실패했습니다."),
+    FORBIDDEN_ERROR(403, "AG304", "해당 팀의 규칙 제안에 접근할 권한이 없습니다."),
     ;
 
     private final int status;

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferController.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferController.java
@@ -20,11 +20,12 @@ public class RuleOfferController {
             description = "Request Body는 Rule Type에 따라서 다른 값을 보냅니다. 모르겠으면 Schema 또는 노션 api 문서를 보세요. or 경서에게 문의"
     )
     @PostMapping("/api/groups/{id}/rules")
-    public ApiResponse<CreateROfferResponse> create(@PathVariable int id, @RequestBody CreateROfferRequest request){
+    public ApiResponse<CreateROfferResponse> create(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId,
+                                                    @PathVariable int id, @RequestBody CreateROfferRequest request){
         return new ApiResponse<>(200,
                 true,
                 "Rule 제안 생성에 성공했습니다.",
-                ruleOfferService.create(id, request));
+                ruleOfferService.create(userId, teamId, id, request));
     }
 
     @Operation(
@@ -32,10 +33,10 @@ public class RuleOfferController {
             description = "response는 규칙의 타입 별로 리스트를 뽑아 줍니다."
     )
     @GetMapping("/api/groups/{id}/rules/offers")
-    public ApiResponse<GetROfferResponse> get(@PathVariable int id){
+    public ApiResponse<GetROfferResponse> get(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId, @PathVariable int id){
         return new ApiResponse(200,
                 true,
                 "Rule 제안 조회에 성공했습니다.",
-                ruleOfferService.get(id));
+                ruleOfferService.get(userId, teamId, id));
     }
 }

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferService.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferService.java
@@ -29,43 +29,41 @@ public class RuleOfferService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
 
-    public CreateROfferResponse create(int teamId, CreateROfferRequest request) {
+    public CreateROfferResponse create(int jwtUserId, int jwtTeamId, int teamId, CreateROfferRequest request) {
+        if (jwtTeamId != teamId) {
+            throw new RuleException(RuleErrorCode.FORBIDDEN_ERROR);
+        }
         // 규칙 제안 생성하기
         // 규칙 제안을 각 타입별로 type에 따라 Join된 테이블에 저장
-
-        // 규칙 타입
         RuleType type = request.getType();
 
-        // Team 찾기
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
         // Team에 속한 멤버 수
         int totalMember = team.getSizeOfMembers();
 
-        // 규칙
         Rule rule = ruleRepository.findByTeam(team).orElseThrow(() -> new RuleException(RuleErrorCode.RULE_NOT_FOUND));
-        // 멤버 찾기
-        Member member = memberRepository.findById(1).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND)); //memberId); // FIXME : memberId 유저 정보로 변경
+        Member member = memberRepository.findByUserIdAndTeamId(jwtUserId, teamId).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        // request를 entity로 변환
         RuleOffer ruleOffer = request.toEntity(rule, member, totalMember);
-
-        // entity를 저장
         ruleOfferRepository.save(ruleOffer);
 
         return CreateROfferResponse.builder()
                 .type(type).build();
     }
 
-    public GetROfferResponse get(int teamId) {
+    public GetROfferResponse get(int jwtUserId, int jwtTeamId, int teamId) {
+        if (jwtTeamId != teamId) {
+            throw new RuleException(RuleErrorCode.FORBIDDEN_ERROR);
+        }
+
         // 규칙 제안 조회하기
         // 규칙 제안을 각 타입별로 type에 따라 Join된 테이블에서 조회
 
-        // Team 찾기
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
         Rule rule = ruleRepository.findByTeam(team).orElseThrow(() -> new RuleException(RuleErrorCode.RULE_NOT_FOUND));
 
-        // repository에서 규칙 제안 조회
-        // 규칙타입 Disband GetROfferResponseType
+        // 규칙 제안 조회
+        // 규칙타입 Disband
         List<GetROfferResponseDisband> offersDisband = getGetROfferResponseDisbands(rule);
 
         // 규칙타입 PayFee

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferService.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferService.java
@@ -55,7 +55,7 @@ public class RuleOfferService {
                 .type(type).build();
     }
 
-    public GetROfferResponse get(int jwtUserId, int jwtTeamId, int teamId) {
+    public GetROfferResponse get(int userId, int jwtTeamId, int teamId) {
         if (jwtTeamId != teamId) {
             throw new RuleException(RuleErrorCode.FORBIDDEN_ERROR);
         }
@@ -66,9 +66,12 @@ public class RuleOfferService {
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
         Rule rule = ruleRepository.findByTeam(team).orElseThrow(() -> new RuleException(RuleErrorCode.RULE_NOT_FOUND));
 
+        // 멤버 id 찾기
+        Member member = memberRepository.findByUserIdAndTeamId(userId, teamId).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
         // 규칙 제안 조회
         // 규칙타입 Disband
-        List<GetROfferResponseDisband> offersDisband = getGetROfferResponseDisbands(rule);
+        List<GetROfferResponseDisband> offersDisband = getGetROfferResponseDisbands(rule, member);
 
         // 규칙타입 PayFee
         List<GetROfferResponsePayFee> offersPayFee = getGetROfferResponsePayFees(rule, member);

--- a/group-investment/src/main/java/com/example/group_investment/team/Team.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/Team.java
@@ -77,4 +77,12 @@ public class Team {
                 .build();
 
     }
+
+    public void cancelTeam() {
+        this.status = TeamStatus.CANCEL;
+    }
+
+    public boolean isPending() {
+        return this.status == TeamStatus.PENDING;
+    }
 }

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamController.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamController.java
@@ -6,6 +6,7 @@ import com.example.group_investment.team.dto.CreateTeamResponse;
 
 import com.example.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,8 +37,10 @@ public class TeamController {
 
     @Operation(summary = "팀을 생성하는 API")
     @PostMapping("")
-    public ApiResponse<CreateTeamResponse> createTeam(@RequestAttribute("userId") int userId, @RequestBody CreateTeamRequest createTeamRequest) {
-        CreateTeamResponse createTeamResponse = teamService.createTeam(userId, createTeamRequest);
+    public ApiResponse<CreateTeamResponse> createTeam(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId,
+                                                      @RequestBody CreateTeamRequest createTeamRequest,
+                                                      HttpServletRequest request) {
+        CreateTeamResponse createTeamResponse = teamService.createTeam(userId, createTeamRequest, teamId, request.getHeader("Authorization").substring(7));
         return new ApiResponse<>(201, true, "팀을 생성했습니다.", createTeamResponse);
     }
 
@@ -58,9 +61,10 @@ public class TeamController {
 
     @Operation(summary = "팀을 참가하는 API")
     @GetMapping("/{id}/participate")
-    public ApiResponse participateTeam(@RequestAttribute("userId") int userId, @PathVariable int id) {
-        teamService.participateTeam(userId, id);
-        return new ApiResponse<>(201, true, "모임에 참가했습니다.", null);
+    public ApiResponse<ParticipateResponse> participateTeam(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId,
+                                                            @PathVariable int id, HttpServletRequest request) {
+        String jwtToken = request.getHeader("Authorization").substring(7);
+        return new ApiResponse<>(201, true, "모임에 참가했습니다.", teamService.participateTeam(userId, id, teamId, jwtToken));
     }
 
     @Operation(summary = "팀을 확정하는 API")

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -346,20 +346,17 @@ public class TeamService {
                 .collect(Collectors.toList());
     }
 
-    public boolean isTeamLeader(int userId, int teamId) {
-        Member member = memberRepository.findByUserIdAndTeamId(userId, teamId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-
+    public boolean isTeamLeader(Member member) {
         return member.getRole() == MemberRole.LEADER;
     }
 
-    public void cancelTeam(int teamId) {
+    public void cancelTeam(Team team) {
         // 팀 상태 CANCEL로 변경
-        Team team = teamRepository.findById(teamId).orElseThrow(()->new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
         team.cancelTeam();
         teamRepository.save(team);
+
         // 멤버 모두 방출
-        List<Member> members = memberRepository.findByTeamId(teamId).orElseThrow(()->new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        List<Member> members = memberRepository.findByTeam(team).orElse(new ArrayList<>());
         for(Member member : members){
             member.cancelMember();
             memberRepository.save(member);

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -284,7 +284,7 @@ public class TeamService {
         return autoPayments;
     }
 
-    public void expelMember(List<PayFail> payFails) {
+    public void cancelMember(List<PayFail> payFails) {
 
         for (PayFail payFail : payFails) {
             int teamId = payFail.getTeamId();
@@ -299,6 +299,13 @@ public class TeamService {
         }
     }
 
+    public void cancelMember(int userId, int teamId) {
+        Member member = memberRepository.findByUserIdAndTeamId(userId, teamId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        member.cancelMember();
+        memberRepository.save(member);
+    }
+
     public List<Integer> selectMemberByTeam(int teamId) {
         List<Member> members = memberRepository.findByTeamId(teamId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -308,6 +315,25 @@ public class TeamService {
                 .collect(Collectors.toList());
     }
 
+    public boolean isTeamLeader(int userId, int teamId) {
+        Member member = memberRepository.findByUserIdAndTeamId(userId, teamId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        return member.getRole() == MemberRole.LEADER;
+    }
+
+    public void cancelTeam(int teamId) {
+        // 팀 상태 CANCEL로 변경
+        Team team = teamRepository.findById(teamId).orElseThrow(()->new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
+        team.cancelTeam();
+        teamRepository.save(team);
+        // 멤버 모두 방출
+        List<Member> members = memberRepository.findByTeamId(teamId).orElseThrow(()->new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        for(Member member : members){
+            member.cancelMember();
+            memberRepository.save(member);
+        }
+    }
 }
 
 

--- a/group-investment/src/main/java/com/example/group_investment/team/dto/CreateTeamResponse.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/dto/CreateTeamResponse.java
@@ -8,5 +8,6 @@ import lombok.Getter;
 public class CreateTeamResponse {
     private String inviteCode;
     private String inviteUrl;
+    private String updatedToken;
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/team/dto/ParticipateResponse.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/dto/ParticipateResponse.java
@@ -1,0 +1,10 @@
+package com.example.group_investment.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipateResponse {
+    private String updatedToken;
+}

--- a/group-investment/src/main/java/com/example/group_investment/team/dto/PayFail.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/dto/PayFail.java
@@ -1,10 +1,12 @@
 package com.example.group_investment.team.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@Builder
 public class PayFail {
     private int teamId;
 

--- a/group-investment/src/main/java/com/example/group_investment/user/User.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/User.java
@@ -1,5 +1,6 @@
 package com.example.group_investment.user;
 
+import com.example.group_investment.enums.UserStatus;
 import com.example.group_investment.member.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
@@ -31,7 +32,9 @@ public class User {
     private String address;
     private String addressDetail;
 
-//    private String role;
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private UserStatus status = UserStatus.ACTIVE;
 
     @OneToMany(mappedBy = "user")
     private List<Member> members;
@@ -48,6 +51,10 @@ public class User {
         this.name = name;
         this.address = address;
         this.addressDetail = addressDetail;
+    }
+
+    public void delete() {
+        this.status = UserStatus.INACTIVE;
     }
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/User.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/User.java
@@ -57,4 +57,7 @@ public class User {
         this.status = UserStatus.INACTIVE;
     }
 
+    public boolean isActive() {
+        return this.status == UserStatus.ACTIVE;
+    }
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/User.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/User.java
@@ -43,4 +43,11 @@ public class User {
         return !members.isEmpty();
     }
 
+    public void updateUserInfo(String email, String name, String address, String addressDetail) {
+        this.email = email;
+        this.name = name;
+        this.address = address;
+        this.addressDetail = addressDetail;
+    }
+
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/User.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/User.java
@@ -29,6 +29,7 @@ public class User {
     private String name;
 
     private String address;
+    private String addressDetail;
 
 //    private String role;
 

--- a/group-investment/src/main/java/com/example/group_investment/user/UserController.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/UserController.java
@@ -50,6 +50,17 @@ public class UserController {
         return new ApiResponse<>(200, true, "사용자 정보를 성공적으로 수정했습니다.", userService.updateUser(userId, request));
     }
 
+    @Operation(summary = "로그아웃")
+    @GetMapping("/api/users/logout")
+    public ApiResponse<?> logout(@RequestAttribute("userId") int userId) {
+        return new ApiResponse<>(200, true, "로그아웃에 성공했습니다.", null);
+    }
+
+    @DeleteMapping("/api/users")
+    public ApiResponse<?> deleteUser(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId) {
+        userService.deleteUser(userId, teamId);
+        return new ApiResponse<>(200, true, "사용자를 삭제했습니다.", null);
+    }
 
     @PostMapping("/api/users/fcm/issue")
     @Operation(summary = "FCM 토큰 발급", description = "유저 ID 와 FCM 토큰을 받아 alarm 모듈에 전송")
@@ -59,7 +70,6 @@ public class UserController {
         
         return new ApiResponse<>(200, true, "토큰을 등록하였습니다.", null);
     }
-
 
 
 

--- a/group-investment/src/main/java/com/example/group_investment/user/UserController.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/UserController.java
@@ -44,6 +44,13 @@ public class UserController {
         return new ApiResponse<>(200, true, "사용 가능한 이메일 입니다.", null);
     }
 
+
+    @PutMapping("/api/users")
+    public ApiResponse<UpdateResponse> updateUser(@RequestAttribute("userId") int userId, @RequestBody UpdateRequest request) {
+        return new ApiResponse<>(200, true, "사용자 정보를 성공적으로 수정했습니다.", userService.updateUser(userId, request));
+    }
+
+
     @PostMapping("/api/users/fcm/issue")
     @Operation(summary = "FCM 토큰 발급", description = "유저 ID 와 FCM 토큰을 받아 alarm 모듈에 전송")
     public ApiResponse<?> saveFcmToken(@RequestBody FcmTokenRequestDto fcmTokenRequestDto) {
@@ -52,5 +59,8 @@ public class UserController {
         
         return new ApiResponse<>(200, true, "토큰을 등록하였습니다.", null);
     }
+
+
+
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/UserController.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/UserController.java
@@ -1,6 +1,7 @@
 package com.example.group_investment.user;
 
 import com.example.common.dto.ApiResponse;
+import com.example.group_investment.auth.exception.AuthoException;
 import com.example.group_investment.user.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -56,6 +57,7 @@ public class UserController {
         return new ApiResponse<>(200, true, "로그아웃에 성공했습니다.", null);
     }
 
+    @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/api/users")
     public ApiResponse<?> deleteUser(@RequestAttribute("userId") int userId, @RequestAttribute("teamId") int teamId) {
         userService.deleteUser(userId, teamId);
@@ -70,7 +72,6 @@ public class UserController {
         
         return new ApiResponse<>(200, true, "토큰을 등록하였습니다.", null);
     }
-
 
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/UserRepository.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/UserRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Integer> {
     Boolean existsByLoginId(String loginId);
     Optional<User> findByLoginId(String loginId);
-
+    boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/UserService.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/UserService.java
@@ -153,8 +153,7 @@ public class UserService {
         *  3. 팀 pending 상태인데 팀장이 아니거나 || 팀장이든 아니든 팀이 ACTIVE 상태라면
         *       팀 탈퇴
         * */
-        List<Member> members = memberRepository.findAllByUserId(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        List<Member> members = memberRepository.findAllByUserId(userId).orElse(new ArrayList<>());
         if (members.isEmpty()) {
             return;
         }

--- a/group-investment/src/main/java/com/example/group_investment/user/UserService.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/UserService.java
@@ -53,6 +53,7 @@ public class UserService {
                 .name(request.getName())
                 .email(request.getEmail())
                 .address(request.getAddress())
+                .addressDetail(request.getAddressDetail())
                 .build();
 
         userRepository.save(createdUser);

--- a/group-investment/src/main/java/com/example/group_investment/user/UserService.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/UserService.java
@@ -144,7 +144,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         user.delete();
-
+        log.info("유저가 탈퇴 처리되었습니다.");
         /* 팀 처리
         *  1. 내가 가진 팀 조회
         *       팀이 없으면 종료
@@ -157,13 +157,16 @@ public class UserService {
         if (members.isEmpty()) {
             return;
         }
+        log.info("참여하고 있는 팀이 있습니다.");
 
         for (Member member : members) {
             Team currentTeam = member.getTeam();
-            if (currentTeam.isPending() && teamService.isTeamLeader(userId, teamId)) {
-                teamService.cancelTeam(teamId);
+            if (currentTeam.isPending() && teamService.isTeamLeader(member)) {
+                System.out.println("펜딩 팀의 팀장이니깐 팀 삭제하겠음");
+                teamService.cancelTeam(currentTeam);
             } else {
-                teamService.cancelMember(userId, teamId);
+                System.out.println("펜딩 팀이 아니거나, 팀장이 아님. 팀 탈퇴하겠음");
+                teamService.cancelMember(userId, currentTeam.getId());
             }
         }
     }

--- a/group-investment/src/main/java/com/example/group_investment/user/dto/GetUserResponse.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/dto/GetUserResponse.java
@@ -13,4 +13,6 @@ public class GetUserResponse {
     private String name;
 
     private String address;
+
+    private String addressDetail;
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/dto/SignUpRequest.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/dto/SignUpRequest.java
@@ -25,5 +25,6 @@ public class SignUpRequest {
     @NotNull
     private String name;
     private String address;
+    private String addressDetail;
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/user/dto/UpdateRequest.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/dto/UpdateRequest.java
@@ -1,0 +1,15 @@
+package com.example.group_investment.user.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+
+@Getter
+@Valid
+public class UpdateRequest {
+    private String name;
+    @Email
+    private String email;
+    private String address;
+    private String addressDetail;
+}

--- a/group-investment/src/main/java/com/example/group_investment/user/dto/UpdateResponse.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/dto/UpdateResponse.java
@@ -1,0 +1,13 @@
+package com.example.group_investment.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UpdateResponse {
+    private String name;
+    private String email;
+    private String address;
+    private String addressDetail;
+}

--- a/group-investment/src/main/java/com/example/group_investment/user/dto/UserDto.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/dto/UserDto.java
@@ -1,0 +1,25 @@
+package com.example.group_investment.user.dto;
+
+import com.example.group_investment.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDto {
+    private String loginId;
+    private String email;
+    private String name;
+    private String address;
+    private String addressDetail;
+
+    public User toEntity(){
+        return User.builder()
+                .loginId(loginId)
+                .email(email)
+                .name(name)
+                .address(address)
+                .addressDetail(addressDetail)
+                .build();
+    }
+}

--- a/group-investment/src/main/java/com/example/group_investment/user/exception/UserErrorCode.java
+++ b/group-investment/src/main/java/com/example/group_investment/user/exception/UserErrorCode.java
@@ -7,7 +7,8 @@ public enum UserErrorCode {
     USER_NOT_FOUND(404, "AG401", "사용자가 존재하지 않습니다."),
     USER_ALREADY_EXISTS(409, "AG901", "이미 존재하는 아이디입니다."),
     EMAIL_ALREADY_EXISTS(409, "AG901", "이미 존재하는 이메일입니다."),
-    FORBIDDEN_ERROR(403, "AG403", "접근 권한이 없습니다.");
+    FORBIDDEN_ERROR(403, "AG403", "접근 권한이 없습니다."),
+    USER_NOT_ACTIVE(403, "AG404", "탈퇴한 사용자입니다.");
 
     private final int status;
     private final String divisionCode;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- [x] 회원가입 시 상세주소 컬럼 추가
- [x] 내 정보 수정
- [x] 회원탈퇴 

아래는 모임생성, 모임 참여시 호출하는 API의 response header에 Authorization 코드를 주도록 수정
- [x] 모임장: 모임 생성 시 new 토큰 발급 => ResponseBody에 추가
- [x] 모임원: 모임 참여 시 new 토큰 발급 => ResponseBody에 추가


### 테스트 결과
- 회원가입 시 상세주소 컬럼 추가
![image](https://github.com/user-attachments/assets/56c5c284-5755-4fce-9c9d-75a11568e65a)

- 내 정보 수정

- 회원탈퇴 시 처리
1. 유저 처리
      * 유저 상태 변경 "삭제" 처리
      * 유저 상태 변경 "탈퇴"
2. 팀 처리
      *  1. 내가 가진 팀 조회 => **팀이 없으면 종료**
      *  2. 팀이 pending 상태 && 그 팀의 팀장이라면 => **팀 삭제**
      *  3. 팀 pending 상태인데 팀장이 아니거나 || 팀장이든 아니든 팀이 ACTIVE 상태라면 => **팀 탈퇴**

- 모임장] 팀 생성
![image](https://github.com/user-attachments/assets/b3aa489d-a510-469f-a6de-80526cf9930a)

- 팀원] 팀 참가
![image](https://github.com/user-attachments/assets/a41f33f5-353b-4841-ae20-3975c34af9cb)
