### PR TITLE
보유 종목 비율 조회(모임 계좌 포트폴리오)

### DIFF
--- a/stock-system/src/main/java/com/example/stock_system/account/exception/AccountErrorCode.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/exception/AccountErrorCode.java
@@ -6,8 +6,9 @@ import lombok.Getter;
 public enum AccountErrorCode {
     ACCOUNT_NOT_FOUND(404, "AG401", "계좌가 존재하지 않습니다."),
     PRIVATE_ACCOUNT_NOT_FOUND(404, "AG402", "개인 계좌가 존재하지 않습니다."),
-    TEAM_ACCOUNT_NOT_FOUND(404, "AG402", "모임계좌, 혹은 모임이 존재하지 않습니다."),
+    TEAM_ACCOUNT_NOT_FOUND(404, "AG403", "모임계좌, 혹은 모임이 존재하지 않습니다."),
     NOT_ENOUGH_DEPOSIT(400, "AG001", "예수금이 부족합니다."),
+    NO_HOLDINGS(404, "AG404", "아무 종목도 보유하고 있지 않습니다."),
     ;
 
     private final int status;

--- a/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsController.java
+++ b/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsController.java
@@ -1,16 +1,12 @@
 package com.example.stock_system.holdings;
 
 import com.example.common.dto.ApiResponse;
+import com.example.stock_system.holdings.dto.GetHoldingsRatioResponse;
 import com.example.stock_system.holdings.dto.HoldingsDto;
 import com.example.stock_system.realTimeStock.RealTimeStockService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Flux;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,11 +18,17 @@ public class HoldingsController {
     private final HoldingsService holdingsService;
     private final RealTimeStockService realTimeStockService;
 
-    @Operation(summary = "장 마감 후 계좌 보유 종목 data 조회",description = "DB에서 데이터를 불러오는 API")
+    @Operation(summary = "장 마감 후 계좌 보유 종목 data 조회", description = "DB에서 데이터를 불러오는 API")
     @GetMapping(value = "/{teamId}")
     public ApiResponse<List<HoldingsDto>> getHoldings(@PathVariable int teamId) {
         List<HoldingsDto> holdingsList = holdingsService.getHoldingsByTeamId(teamId);
         return new ApiResponse<>(200, true, "보유종목을 조회했습니다.", holdingsList);
+    }
+
+    @Operation(summary = "장 마감 후 보유 종목 비율 조회", description = "계좌의 총 평가금액 대비 보유 종목의 비율을 조회하는 API")
+    @GetMapping(value = "/ratio")
+    public ApiResponse<List<GetHoldingsRatioResponse>> getHoldingsRatio(@RequestAttribute("teamId") int teamId) {
+        return new ApiResponse<>(200, true, "보유종목 비율을 조회했습니다.", holdingsService.getHoldingsRatio(teamId));
     }
 
 

--- a/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsService.java
+++ b/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsService.java
@@ -130,6 +130,10 @@ public class HoldingsService {
 
         Account account = teamAccount.getAccount();
 
+        if (account.getTotalEvluAmt() == 0) {
+            throw new AccountException(AccountErrorCode.NO_HOLDINGS);
+        }
+
         List<Holdings> holdings = holdingsRepository.findByAccount(account);
         return holdings.stream()
                 .map(holding -> GetHoldingsRatioResponse.builder()

--- a/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsService.java
+++ b/stock-system/src/main/java/com/example/stock_system/holdings/HoldingsService.java
@@ -7,6 +7,7 @@ import com.example.stock_system.account.exception.AccountErrorCode;
 import com.example.stock_system.account.exception.AccountException;
 import com.example.stock_system.enums.TradeStatus;
 import com.example.stock_system.enums.TradeType;
+import com.example.stock_system.holdings.dto.GetHoldingsRatioResponse;
 import com.example.stock_system.holdings.dto.HoldingsDto;
 import com.example.stock_system.holdings.dto.SaveClosingPrice;
 import com.example.stock_system.holdings.exception.HoldingsErrorCode;
@@ -121,5 +122,20 @@ public class HoldingsService {
         int pendingBuyAmount = trades.stream().mapToInt(trade -> trade.getPrice() * trade.getQuantity()).sum();
 
         return account.getDeposit() - pendingBuyAmount;
+    }
+
+    public List<GetHoldingsRatioResponse> getHoldingsRatio(int teamId) {
+        TeamAccount teamAccount = teamAccountRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+
+        Account account = teamAccount.getAccount();
+
+        List<Holdings> holdings = holdingsRepository.findByAccount(account);
+        return holdings.stream()
+                .map(holding -> GetHoldingsRatioResponse.builder()
+                        .stockName(holding.getStockCode().getName())
+                        .ratio(Math.round((holding.getEvluAmt() / (double) account.getTotalEvluAmt()) * 100) / 100.0)
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/stock-system/src/main/java/com/example/stock_system/holdings/dto/GetHoldingsRatioResponse.java
+++ b/stock-system/src/main/java/com/example/stock_system/holdings/dto/GetHoldingsRatioResponse.java
@@ -1,0 +1,16 @@
+package com.example.stock_system.holdings.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GetHoldingsRatioResponse {
+    private String stockName;
+    private double ratio;
+
+    @Builder
+    public GetHoldingsRatioResponse(String stockName, double ratio) {
+        this.stockName = stockName;
+        this.ratio = ratio;
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 모임이 보유하고 있는 종목의 비율을 계산하여 응답합니다.
- 모임이 아무런 종목도 보유하고 있지 않는 경우(혹은 모임 계좌의 총 평가금액이 0인 경우), `아무 종목도 보유하고 있지 않습니다.`라는 예외 발생

### 테스트 결과
- api 정상 작동
<img width="787" alt="image" src="https://github.com/user-attachments/assets/b7b726e6-4303-4478-97a5-c76e8e80939f">

