### PR TITLE
계좌 관련 로직(팀 생성과정)

### DIFF
--- a/group-investment/src/main/java/com/example/group_investment/backend_only/BackendController.java
+++ b/group-investment/src/main/java/com/example/group_investment/backend_only/BackendController.java
@@ -3,6 +3,7 @@ package com.example.group_investment.backend_only;
 import com.example.common.dto.ApiResponse;
 import com.example.group_investment.team.TeamService;
 import com.example.group_investment.team.dto.AutoPayment;
+import com.example.group_investment.team.dto.FirstPayment;
 import com.example.group_investment.team.dto.PayFail;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
@@ -35,6 +36,14 @@ public class BackendController {
     @GetMapping("/member")
     public ApiResponse selectMemberByTeam(@RequestParam int teamId){
         return new ApiResponse<>(200,true,"해당 팀 id의 유저 리스트",teamService.selectMemberByTeam(teamId));
+    }
+
+    @Operation(summary = "팀에 들어갈때 내야하는 돈",description = "팀 아이디,내야하는 돈, 내야할 사람들 id리스트")
+    @GetMapping("/first-payment")
+    public ApiResponse createFirstPayment(@RequestParam int teamId){
+        FirstPayment firstPayment = teamService.createFirstPayment(teamId);
+        return new ApiResponse<>(200,true,"초기에 내야하는 돈",firstPayment);
+
     }
 
     @Operation(summary = "팀 id로 유저 이름 찾아오기",description = "채팅창에 띄울 용도")

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -326,6 +326,25 @@ public class TeamService {
                 .collect(Collectors.toList());
     }
 
+
+    public FirstPayment createFirstPayment(int teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
+
+        List<Member> members = memberRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        List<Integer> userIds = members.stream()
+                .map(member -> member.getUser().getId())
+                .collect(Collectors.toList());
+
+        int paymentMoney = team.getBaseAmt();
+
+        return new FirstPayment(teamId, paymentMoney, userIds);
+    }
+
+
+
 }
 
 

--- a/group-investment/src/main/java/com/example/group_investment/team/dto/FirstPayment.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/dto/FirstPayment.java
@@ -1,0 +1,19 @@
+package com.example.group_investment.team.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FirstPayment {
+
+    private int teamId;
+    private int paymentMoney;
+    private List<Integer> users;
+
+    public FirstPayment(int teamId,int paymentMoney, List<Integer> users){
+        this.teamId = teamId;
+        this.paymentMoney = paymentMoney;
+        this.users = users;
+    }
+}

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
@@ -36,8 +36,8 @@ public class AccountController {
 
     @Operation(summary = "팀 계좌 생성",description = "비밀번호를 입력값으로 받아 팀 계좌를 생성해줍니다.")
     @PostMapping("/team")
-    public ApiResponse<AccountDto> createTeamAccount(@RequestBody CreateAccountRequest createAccountRequest){
-        Account savedAccount = accountService.createTeamAccount(createAccountRequest.getName(),createAccountRequest.getUserId());
+    public ApiResponse<AccountDto> createTeamAccount(@RequestBody CreateAccountRequest createAccountRequest,@RequestAttribute("teamId") int teamId){
+        Account savedAccount = accountService.createTeamAccount(createAccountRequest.getName(),createAccountRequest.getUserId(),teamId);
         accountService.createAccountPInfo(savedAccount,createAccountRequest);
         return new ApiResponse<>(201, true, "모임 계좌가 생성되었습니다.", null);
     }
@@ -64,7 +64,7 @@ public class AccountController {
         return accountService.getRealTimeSumByTeamId(teamId);
     }
 
-    @Operation(summary = "자동 이체 서비스",description = "test를 위해 호출식으로 작성, 추후에 배치로 처리")
+    @Operation(summary = "자동 전량 매도 서비스",description = "test를 위해 호출식으로 작성, 추후에 배치로 처리")
     @GetMapping("/all-stock-sell/{teamId}")
     public ApiResponse<Integer> allStockSell(@PathVariable int teamId) {
         int sellMoeny = accountService.allStockSell(teamId);

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -41,18 +42,25 @@ public class AccountService {
         return accountDtoConverter.fromEntity(account);
     }
 
-    public Account createTeamAccount(String name, int userId) {
+    public Account createTeamAccount(String name, int userId,int teamId) {
 
         String accountNumber = "81902" + generateRandomNumber();
         Account account = new Account(name, userId, accountNumber);
+        Account savedAccount = accountRepository.save(account);
 
-        return accountRepository.save(account);
+        TeamAccount teamAccount = new TeamAccount(savedAccount,teamId);
+        teamAccountRepository.save(teamAccount);
+
+        processFirstPayment(teamId);
+
+        return savedAccount;
     }
 
     public Account createPersonalAccount(String name, int userId) {
 
         String accountNumber = "81901" + generateRandomNumber();
         Account account = new Account(name, userId, accountNumber);
+        account.sellStock(25000000);
 
         return accountRepository.save(account);
     }
@@ -221,9 +229,57 @@ public class AccountService {
     }
 
 
+
     public void stopRealTimeStream(int teamId) {
         realTimeStockService.stopStreamingByTeamId(teamId);
     }
 
+    public FirstPayment getFirstPaymentFromAPI(int teamId) {
+        String url = "http://localhost:8081/api/backend/first-payment?teamId=" + teamId;
+
+        ResponseEntity<ApiResponse> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                ApiResponse.class
+        );
+
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        FirstPayment firstPayment = objectMapper.convertValue(response.getBody().getData(), FirstPayment.class);
+
+        return firstPayment;
+    }
+
+    @Transactional
+    public void processFirstPayment(int teamId) {
+
+
+        FirstPayment firstPayment = getFirstPaymentFromAPI(teamId);
+
+
+        TeamAccount teamAccount = teamAccountRepository.findByTeamId(firstPayment.getTeamId())
+                .orElseThrow(() -> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+
+        Account teamAccountEntity = teamAccount.getAccount();
+
+        int paymentAmount = firstPayment.getPaymentMoney();
+
+        List<Integer> userIds = firstPayment.getUsers();
+
+        for (Integer userId : userIds) {
+            Account personalAccount = getPersonalAccount(userId);
+
+            if (personalAccount.getDeposit() >= paymentAmount) {
+                personalAccount.buyStock(paymentAmount);
+                accountRepository.save(personalAccount);
+
+                teamAccountEntity.sellStock(paymentAmount);
+                accountRepository.save(teamAccountEntity);
+            } else {
+                throw new AccountException(AccountErrorCode.NOT_ENOUGH_DEPOSIT);
+            }
+        }
+    }
 
 }

--- a/stock-system/src/main/java/com/example/stock_system/account/TeamAccount.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/TeamAccount.java
@@ -21,4 +21,9 @@ public class TeamAccount {
     @Column(name = "team_id")
     private int teamId;
 
+
+    public TeamAccount(Account account, int teamId) {
+        this.account = account;
+        this.teamId = teamId;
+    }
 }

--- a/stock-system/src/main/java/com/example/stock_system/account/dto/FirstPayment.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/dto/FirstPayment.java
@@ -1,0 +1,23 @@
+package com.example.stock_system.account.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FirstPayment {
+
+    private int teamId;
+    private int paymentMoney;
+    private List<Integer> users;
+
+    public FirstPayment(){
+
+    }
+
+    public FirstPayment(int teamId,int paymentMoney, List<Integer> users){
+        this.teamId = teamId;
+        this.paymentMoney = paymentMoney;
+        this.users = users;
+    }
+}


### PR DESCRIPTION
### PR 타입
-[x] 기능 추가
-[x] 기능 수정
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1.개인 계좌 생성 시 초기 자금 2500만원 지급
2. 팀 확정 후 계좌 생성 시 팀 룰에 있는 초기 자금 만큼 해당 팀의 멤버에게 인출 후 팀 계좌로 전송
3. 팀 확정 후 계좌 생성 시 team_account table에 teamId와 accountId 추가

### 테스트 결과
![image](https://github.com/user-attachments/assets/7992bdd2-31ed-445a-a3cb-63aaadead690)


![image](https://github.com/user-attachments/assets/fbe20c08-fe04-42c4-acee-2ba97882bf41)


![image](https://github.com/user-attachments/assets/c9d7b2bb-f7cc-4d91-adab-4b9f2a3ae1ad)
