### PR TITLE
팀 펜딩 상태일때 조회 api 에서 참여안한 user 의 경우 member not found 뜨는 오류 수정

### DIFF
--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -23,7 +23,6 @@ import com.example.group_investment.user.UserRepository;
 import com.example.group_investment.user.exception.UserErrorCode;
 import com.example.group_investment.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.mapping.Join;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -151,10 +150,16 @@ public class TeamService {
         RuleDto ruleDto = rule.fromEntity(rule);
         //2-3. is 모임장
         int isLeader = 0;
-        if (memberRepository.findByUserIdAndTeamId(userId, teamId).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND))
-                .getRole() == MemberRole.LEADER)
-            isLeader = 1;
+        
+        List<Member> joinedMembers = memberRepository.findByTeam(team).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        for (Member member : joinedMembers) {
+            if (member.getUser().getId() == userId) {
+                if (member.getRole()==MemberRole.LEADER)
+                    isLeader = 1;
+            }
+        }
         //2-4. is 참여
+
         int isParticipating = 0;
         if (isLeader == 0) {
             List<Member> members = memberRepository.findByTeam(team).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
펜딩 상태 조회 api 에서 참여안한 user 의 경우 member not found 뜨는 오류 수정했습니다. 
isLeader 여부 찾는 코드에서 userid , teamid 를 멤버를 조회해서 없는경우는 error code를 보내서 발생한 오류입니다

### 테스트 결과
![image](https://github.com/user-attachments/assets/8467ef33-a5b9-4373-b05a-494dbab3c7cd)
