### PR TITLE
팀을 생성할때 랭킹에 data가 추가되도록 수정

### DIFF
--- a/chatting/src/main/java/com/example/chatting/service/ChatRoomService.java
+++ b/chatting/src/main/java/com/example/chatting/service/ChatRoomService.java
@@ -91,7 +91,6 @@ public class ChatRoomService {
 
     public List<String> getTeamMemberNames(int teamId) {
 
-        System.out.println("되나?");
         String url = teamServiceUrl + "?teamId=" + teamId;
         ResponseEntity<ApiResponse> response = restTemplate.getForEntity(url, ApiResponse.class);
 

--- a/group-investment/src/main/java/com/example/group_investment/backend_only/BackendController.java
+++ b/group-investment/src/main/java/com/example/group_investment/backend_only/BackendController.java
@@ -52,4 +52,10 @@ public class BackendController {
         return new ApiResponse<>(200, true, "유저 들의 이름 list",teamService.selectMemberNameByTeam(teamId));
     }
 
+
+    @GetMapping("/team-category")
+    public ApiResponse getTeamCategory(@RequestParam int teamId){
+        return new ApiResponse<>(200,true,"팀 id에 해당하는 카테고리",teamService.getTeamCategory(teamId));
+    }
+
 }

--- a/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
+++ b/group-investment/src/main/java/com/example/group_investment/team/TeamService.java
@@ -1,10 +1,7 @@
 package com.example.group_investment.team;
 
 import com.example.group_investment.auth.AuthService;
-import com.example.group_investment.enums.JoinStatus;
-import com.example.group_investment.enums.MemberRole;
-import com.example.group_investment.enums.RulePeriod;
-import com.example.group_investment.enums.TeamStatus;
+import com.example.group_investment.enums.*;
 import com.example.group_investment.member.Member;
 import com.example.group_investment.member.MemberRepository;
 import com.example.group_investment.member.dto.MemberDto;
@@ -381,6 +378,13 @@ public class TeamService {
             memberRepository.save(member);
         }
     }
+
+
+    public Category getTeamCategory(int teamId){
+        Team findteam = teamRepository.findById(teamId).orElseThrow(()->new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
+        return findteam.getCategory();
+    }
+
 }
 
 

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
@@ -4,6 +4,7 @@ import com.example.stock_system.account.dto.*;
 import com.example.common.dto.ApiResponse;
 import com.example.stock_system.holdings.HoldingsService;
 import com.example.stock_system.holdings.dto.HoldingsDto;
+import com.example.stock_system.ranking.RankingService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
@@ -17,7 +18,7 @@ import java.util.List;
 public class AccountController {
     private final AccountService accountService;
     private final HoldingsService holdingsService;
-
+    private final RankingService rankingService;
 
     @Operation(summary = "계좌 조회",description = "Account의 Id를 통해 계좌를 조회합니다.")
     @GetMapping("/{id}")
@@ -39,6 +40,7 @@ public class AccountController {
     public ApiResponse<AccountDto> createTeamAccount(@RequestBody CreateAccountRequest createAccountRequest,@RequestAttribute("teamId") int teamId){
         Account savedAccount = accountService.createTeamAccount(createAccountRequest.getName(),createAccountRequest.getUserId(),teamId);
         accountService.createAccountPInfo(savedAccount,createAccountRequest);
+        rankingService.registRanking(savedAccount);
         return new ApiResponse<>(201, true, "모임 계좌가 생성되었습니다.", null);
     }
 

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
@@ -4,7 +4,6 @@ import com.example.common.dto.ApiResponse;
 import com.example.stock_system.account.dto.*;
 import com.example.stock_system.account.exception.AccountErrorCode;
 import com.example.stock_system.account.exception.AccountException;
-import com.example.stock_system.enums.Category;
 import com.example.stock_system.holdings.Holdings;
 import com.example.stock_system.holdings.HoldingsRepository;
 import com.example.stock_system.holdings.dto.HoldingsDto;
@@ -15,7 +14,6 @@ import com.example.stock_system.realTimeStock.RealTimeStockService;
 import com.example.stock_system.stocks.StocksService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -245,7 +243,7 @@ public class AccountService {
     }
 
     public FirstPayment getFirstPaymentFromAPI(int teamId) {
-        String url = "http://localhost:8081/api/backend/first-payment?teamId=" + teamId;
+        String url = "http://localhost:8081/api/group/backend/first-payment?teamId=" + teamId;
 
         ResponseEntity<ApiResponse> response = restTemplate.exchange(
                 url,

--- a/stock-system/src/main/java/com/example/stock_system/ranking/Ranking.java
+++ b/stock-system/src/main/java/com/example/stock_system/ranking/Ranking.java
@@ -28,6 +28,13 @@ public class Ranking {
     private int seedMoney;
     private double evluPflsRt;
 
+    public Ranking(Category category, Account account, int teamId, int seedMoney, double evluPflsRt) {
+        this.category = category;
+        this.account = account;
+        this.teamId = teamId;
+        this.seedMoney = seedMoney;
+        this.evluPflsRt = evluPflsRt;
+    }
     public Ranking() {
 
     }

--- a/stock-system/src/main/java/com/example/stock_system/ranking/RankingController.java
+++ b/stock-system/src/main/java/com/example/stock_system/ranking/RankingController.java
@@ -1,13 +1,10 @@
 package com.example.stock_system.ranking;
 
 import com.example.common.dto.ApiResponse;
-import com.example.stock_system.ranking.dto.SelectRankingResponse;
 import com.example.stock_system.ranking.dto.SelectRankingWithTeamResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @AllArgsConstructor

--- a/stock-system/src/main/java/com/example/stock_system/ranking/RankingService.java
+++ b/stock-system/src/main/java/com/example/stock_system/ranking/RankingService.java
@@ -1,13 +1,24 @@
 package com.example.stock_system.ranking;
 
+import com.example.common.dto.ApiResponse;
+import com.example.stock_system.account.Account;
+import com.example.stock_system.account.TeamAccount;
+import com.example.stock_system.account.TeamAccountRepository;
+import com.example.stock_system.account.exception.AccountErrorCode;
+import com.example.stock_system.account.exception.AccountException;
+import com.example.stock_system.enums.Category;
 import com.example.stock_system.ranking.dto.SelectRankingResponse;
 import com.example.stock_system.ranking.dto.SelectRankingWithTeamResponse;
 import com.example.stock_system.ranking.exception.RankingErrorCode;
 import com.example.stock_system.ranking.exception.RankingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,7 +26,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RankingService {
 
+    @Value("${ag.url}")
+    private String AG_URL;
+
     private final RankingRepository rankingRepository;
+    private final TeamAccountRepository teamAccountRepository;
+    private final RestTemplate restTemplate;
 
     public SelectRankingWithTeamResponse selectRanking(int teamId, int maxSeedMoney) {
         int minSeedMoney;
@@ -49,5 +65,19 @@ public class RankingService {
                 .teamRanking(teamRanking)
                 .rankings(rankingResponses)
                 .build();
+    }
+
+    public void registRanking(Account savedAccount){
+        TeamAccount teamAccount = teamAccountRepository.findByAccount(savedAccount).orElseThrow(()-> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+        int teamId = teamAccount.getTeamId();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String url = AG_URL+"/api/group/backend/team-category?teamId="+teamId;
+
+        ResponseEntity<ApiResponse> response = restTemplate.getForEntity(url, ApiResponse.class);
+        Category teamCategory = objectMapper.convertValue(response.getBody().getData(), new TypeReference<Category>() {});
+
+        rankingRepository.save(new Ranking(teamCategory,savedAccount,teamId,savedAccount.getDeposit(),savedAccount.getTotalEvluPflsRt()));
     }
 }

--- a/stock-system/src/main/java/com/example/stock_system/ranking/RankingService.java
+++ b/stock-system/src/main/java/com/example/stock_system/ranking/RankingService.java
@@ -78,6 +78,6 @@ public class RankingService {
         ResponseEntity<ApiResponse> response = restTemplate.getForEntity(url, ApiResponse.class);
         Category teamCategory = objectMapper.convertValue(response.getBody().getData(), new TypeReference<Category>() {});
 
-        rankingRepository.save(new Ranking(teamCategory,savedAccount,teamId,savedAccount.getDeposit(),savedAccount.getTotalEvluPflsRt()));
+        rankingRepository.save(new Ranking(teamCategory,savedAccount,teamId,savedAccount.getDeposit()+savedAccount.getTotalEvluAmt(),savedAccount.getTotalEvluPflsRt()));
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

랭킹 table에 초기 data를 넣어놓기 위해. (업데이트 하더라도 그 전에 확인할 수 있도록) 팀을 생성할 때 자동으로 랭킹 table에 data가 들어가도록 처리

### 테스트 결과

![image](https://github.com/user-attachments/assets/ee24d052-d283-4e89-a4cb-25a9db20c127)
