### PR TITLE
팀 계좌 조회시 보유 종목이 없으면 0 값으로 출력하도록 처리

### DIFF
--- a/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
@@ -20,12 +20,6 @@ public class AccountController {
     private final HoldingsService holdingsService;
     private final RankingService rankingService;
 
-    @Operation(summary = "계좌 조회",description = "Account의 Id를 통해 계좌를 조회합니다.")
-    @GetMapping("/{id}")
-    public ApiResponse<AccountDto> getAccount(@PathVariable("id") int id) {
-        AccountDto accountDto = accountService.getAccount(id);
-        return new ApiResponse<>(200, true, "계좌를 조회했습니다.", accountDto);
-    }
 
     @Operation(summary = "개인 계좌 생성",description = "비밀번호를 입력값으로 받아 개인 계좌를 생성해줍니다.")
     @PostMapping("/personal")
@@ -61,7 +55,7 @@ public class AccountController {
     }
 
     @Operation(summary = "실시간 계좌 보유 종목 합 data 조회", description = "실시간 데이터를 불러오는 API")
-    @GetMapping(value = "/realtime-sum/{teamId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/sum-realtime/{teamId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<GetTeamAccountResponse> streamRealTimeSumByTeamId(@PathVariable int teamId) {
         return accountService.getRealTimeSumByTeamId(teamId);
     }

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -170,15 +171,17 @@ public class AccountService {
                                 .subscribeOn(Schedulers.boundedElastic())
                                 .flatMapMany(holdingsList -> {
                                     if (holdingsList.isEmpty()) {
-                                        return Flux.just(GetTeamAccountResponse.builder()
-                                                .accountNumber(account.getAccountNumber())
-                                                .totalPchsAmt(0)
-                                                .totalEvluAmt(0)
-                                                .totalEvluPfls(0)
-                                                .totalEvluPflsRt(0.0)
-                                                .deposit(account.getDeposit())
-                                                .totalAsset(account.getDeposit())
-                                                .build());
+                                        // holdings가 없을 때 빈 데이터를 지속적으로 전송하여 연결이 끊기지 않도록 함
+                                        return Flux.interval(Duration.ofSeconds(1))
+                                                .map(tick -> GetTeamAccountResponse.builder()
+                                                        .accountNumber(account.getAccountNumber())
+                                                        .totalPchsAmt(0)
+                                                        .totalEvluAmt(0)
+                                                        .totalEvluPfls(0)
+                                                        .totalEvluPflsRt(0.0)
+                                                        .deposit(account.getDeposit())
+                                                        .totalAsset(account.getDeposit())
+                                                        .build());
                                     }
 
                                     List<String> stockCodes = holdingsList.stream()

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
@@ -330,7 +330,6 @@ public class AccountService {
             }
         }
     }
-}
     public void createRanking() {
 
         List<Account> accounts = accountRepository.findByAccountNumberStartingWith("81902").orElseThrow(()->new AccountException(AccountErrorCode.TEAM_ACCOUNT_NOT_FOUND));
@@ -351,4 +350,6 @@ public class AccountService {
 
         rankingRepository.saveAll(rankings);
     }
+
 }
+


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

팀 계좌 조회시 보유 종목이 없으면 0 값으로 출력하도록 처리


### 테스트 결과

![image](https://github.com/user-attachments/assets/107113ce-d4de-4fcf-bb60-d840acd6d5c5)
