### PR TITLE
대시보드 API 병합+invest-ref서버라우팅변경+GET규칙제안이름추가

### DIFF
--- a/ag-gateway/src/main/java/com/example/ag_gateway/config/RouteConfig.java
+++ b/ag-gateway/src/main/java/com/example/ag_gateway/config/RouteConfig.java
@@ -81,12 +81,7 @@ public class RouteConfig {
     @Bean
     public RouterFunction<ServerResponse> investRefRouter(){
         return route("invest-reference")
-                .route(path(
-                        "/api/news/**",
-                        "/api/markey-issue/**",
-                        "/api/rising-ranking/**",
-                        "/api/issue/**"
-                ), http(investRefUrl))
+                .route(path("/api/ref/**"), http(investRefUrl))
                 .build();
     }
 

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferService.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/RuleOfferService.java
@@ -16,6 +16,7 @@ import com.example.group_investment.team.Team;
 import com.example.group_investment.team.TeamRepository;
 import com.example.group_investment.team.exception.TeamErrorCode;
 import com.example.group_investment.team.exception.TeamException;
+import com.example.group_investment.user.User;
 import lombok.AllArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
@@ -111,6 +112,7 @@ public class RuleOfferService {
                         .totalvotes(offerDisband.getTotalvotes())
                         .maxLossRt(offerDisband.getMaxLossRt())
                         .maxProfitRt(offerDisband.getMaxProfitRt())
+                        .name(member.getUser().getName())
                         .build()
                 )
                 .collect(Collectors.toList());
@@ -132,6 +134,7 @@ public class RuleOfferService {
                         .depositAmt(offerPayFee.getDepositAmt())
                         .period(offerPayFee.getPeriod())
                         .payDate(offerPayFee.getPayDate())
+                        .name(member.getUser().getName())
                         .build()
                 )
                 .collect(Collectors.toList());
@@ -152,6 +155,7 @@ public class RuleOfferService {
                         .downvotes(offerUpvoteNumber.getDownvotes())
                         .totalvotes(offerUpvoteNumber.getTotalvotes())
                         .tradeUpvotes(offerUpvoteNumber.getTradeUpvotes())
+                        .name(member.getUser().getName())
                         .build()
                 )
                 .collect(Collectors.toList());
@@ -173,6 +177,7 @@ public class RuleOfferService {
                         .totalvotes(offerUrgentSale.getTotalvotes())
                         .tradeUpvotes(offerUrgentSale.getTradeUpvotes())
                         .prdyVrssRt(offerUrgentSale.getPrdyVrssRt())
+                        .name(member.getUser().getName())
                         .build()
                 )
                 .collect(Collectors.toList());

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponseDisband.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponseDisband.java
@@ -24,8 +24,9 @@ public class GetROfferResponseDisband implements GetROfferResponseType {
     double maxProfitRt;
 
     boolean isVote;
+    String name;
 
-    public GetROfferResponseDisband(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalvotes, double maxLossRt, double maxProfitRt, boolean isVote) {
+    public GetROfferResponseDisband(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalvotes, double maxLossRt, double maxProfitRt, boolean isVote, String name) {
         this.type = type;
         this.id = id;
         this.status = status;
@@ -35,6 +36,7 @@ public class GetROfferResponseDisband implements GetROfferResponseType {
         this.maxLossRt = maxLossRt;
         this.maxProfitRt = maxProfitRt;
         this.isVote = isVote;
+        this.name = name;
     }
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponsePayFee.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponsePayFee.java
@@ -29,8 +29,9 @@ public class GetROfferResponsePayFee implements GetROfferResponseType {
     LocalDate payDate;
 
     boolean isVote;
+    String name;
 
-    public GetROfferResponsePayFee(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalvotes, int depositAmt, RulePeriod period, LocalDate payDate, boolean isVote) {
+    public GetROfferResponsePayFee(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalvotes, int depositAmt, RulePeriod period, LocalDate payDate, boolean isVote, String name) {
         this.type = type;
         this.id = id;
         this.status = status;
@@ -41,6 +42,7 @@ public class GetROfferResponsePayFee implements GetROfferResponseType {
         this.period = period;
         this.payDate = payDate;
         this.isVote = isVote;
+        this.name = name;
     }
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponseUpvoteNumber.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponseUpvoteNumber.java
@@ -21,8 +21,9 @@ public class GetROfferResponseUpvoteNumber implements GetROfferResponseType{
 
     int tradeUpvotes;
     boolean isVote;
+    String name;
 
-    public GetROfferResponseUpvoteNumber(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalVotes, int tradeUpvotes, boolean isVote) {
+    public GetROfferResponseUpvoteNumber(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalVotes, int tradeUpvotes, boolean isVote, String name) {
         this.type = type;
         this.id = id;
         this.status = status;
@@ -31,6 +32,7 @@ public class GetROfferResponseUpvoteNumber implements GetROfferResponseType{
         this.totalvotes = totalVotes;
         this.tradeUpvotes = tradeUpvotes;
         this.isVote = isVote;
+        this.name = name;
     }
 
 }

--- a/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponseUrgentSale.java
+++ b/group-investment/src/main/java/com/example/group_investment/ruleOffer/dto/GetROfferResponseUrgentSale.java
@@ -24,7 +24,9 @@ public class GetROfferResponseUrgentSale implements GetROfferResponseType {
 
     boolean isVote;
 
-    public GetROfferResponseUrgentSale(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalvotes, int tradeUpvotes, double prdyVrssRt, boolean isVote) {
+    String name;
+
+    public GetROfferResponseUrgentSale(RuleType type, int id, OfferStatus status, int upvotes, int downvotes, int totalvotes, int tradeUpvotes, double prdyVrssRt, boolean isVote, String name) {
         this.type = type;
         this.id = id;
         this.status = status;
@@ -34,6 +36,7 @@ public class GetROfferResponseUrgentSale implements GetROfferResponseType {
         this.tradeUpvotes = tradeUpvotes;
         this.prdyVrssRt = prdyVrssRt;
         this.isVote = isVote;
+        this.name = name;
     }
 
 }

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefController.java
@@ -1,6 +1,7 @@
 package com.example.invest_references;
 
 import com.example.common.dto.ApiResponse;
+import com.example.invest_references.dto.GetIssueResponse;
 import com.example.invest_references.dto.MarketIndexResponse;
 import com.example.invest_references.dto.News;
 import com.example.invest_references.dto.ShinhanData;
@@ -31,22 +32,10 @@ public class InvestRefController {
         return new ApiResponse<>(200, true, "코스피/코스닥 지수를 가져왔습니다.", investRefService.getMarketIndex());
     }
 
-    @Operation(summary = "증권_공개형API_인기주식_지금뜨는테마보기",description = "신투 기준 인기 주식 가져옴")
-    @GetMapping("/rising-ranking")
-    public ApiResponse<List<ShinhanData>> getRisingRanking() throws JsonProcessingException{
-        return new ApiResponse<>(200, true, "실시간 현재가 조회수가 높은 종목 출력",investRefService.getRisingRanking());
+    @Operation(summary = "대시보드에 필요한 API", description = "증권_공개형API_인기주식_지금뜨는테마보기 / 증권_공개형API_핫이슈종목_시장상위종목-거래량 기준 / 증권_공개형API_핫이슈종목_시장상위종목-수익률 기준")
+    @GetMapping("/issue")
+    public ApiResponse<GetIssueResponse> getIssue() throws JsonProcessingException {
+        return new ApiResponse<>(200, true, "성공적으로 전달하였습니다.", investRefService.getIssue());
     }
 
-    @Operation(summary = "증권_공개형API_핫이슈종목_시장상위종목-거래량 기준",description = "신투 기준 거래량 상위 주식 가져옴")
-    @GetMapping("/issue/volume")
-    public ApiResponse<List<ShinhanData>> getVolumeRanking() throws JsonProcessingException{
-        return new ApiResponse<>(200,true,"거래량 기준 높은 종목 출력",investRefService.getVolumeRanking());
-    }
-
-
-    @Operation(summary = "증권_공개형API_핫이슈종목_시장상위종목-수익률 기준",description = "신투 기준 수익률 상위 주식 가져옴")
-    @GetMapping("/issue/earning")
-    public ApiResponse<List<ShinhanData>> getEarningRanking() throws JsonProcessingException{
-        return new ApiResponse<>(200,true,"수익률 기준 높은 종목 출력",investRefService.getEarningRanking());
-    }
 }

--- a/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
+++ b/invest-references/src/main/java/com/example/invest_references/InvestRefService.java
@@ -241,6 +241,19 @@ public class InvestRefService {
             throw new InvestRefException(InvestRefErrorCode.FAILED_TO_GET_EARNING);
         }
     }
+
+    public GetIssueResponse getIssue() throws JsonProcessingException {
+
+        List<ShinhanData> rising = getRisingRanking();
+        List<ShinhanData> volume = getVolumeRanking();
+        List<ShinhanData> earning = getEarningRanking();
+
+        return GetIssueResponse.builder()
+                .risingRanking(rising)
+                .hotVolume(volume)
+                .hotEarning(earning)
+                .build();
+    }
 }
 
 

--- a/invest-references/src/main/java/com/example/invest_references/dto/GetIssueResponse.java
+++ b/invest-references/src/main/java/com/example/invest_references/dto/GetIssueResponse.java
@@ -1,2 +1,14 @@
-package com.example.invest_references.dto;public class GetIssueResponse {
+package com.example.invest_references.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class GetIssueResponse {
+    List<ShinhanData> risingRanking;
+    List<ShinhanData> hotVolume;
+    List<ShinhanData> hotEarning;
 }

--- a/invest-references/src/main/java/com/example/invest_references/dto/GetIssueResponse.java
+++ b/invest-references/src/main/java/com/example/invest_references/dto/GetIssueResponse.java
@@ -1,0 +1,2 @@
+package com.example.invest_references.dto;public class GetIssueResponse {
+}


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 대시보드 API 하나로 통합
- invest-reference 서버 라우팅 변경
- GET 규칙 제안의 response 컬럼에 제안자 이름 추가

### 테스트 결과
- 대시보드 API 하나로 통합
![image](https://github.com/user-attachments/assets/df9bf808-7703-4457-b8a9-ba17a99a50b5)
![image](https://github.com/user-attachments/assets/a99ba5b6-70d1-46e4-ba8d-f2c712e7e40b)


- GET 규칙 제안의 response 컬럼에 제안자 이름 추가
![image](https://github.com/user-attachments/assets/5b1a50d5-0004-45ac-a153-d337443c4dca)

