### PR TITLE
계좌 조회 api 분리(DB에 있는 값 불러오는 api)

### DIFF
--- a/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
@@ -1,7 +1,7 @@
 package com.example.stock_system.account;
 
-import com.example.stock_system.account.dto.*;
 import com.example.common.dto.ApiResponse;
+import com.example.stock_system.account.dto.*;
 import com.example.stock_system.holdings.HoldingsService;
 import com.example.stock_system.holdings.dto.HoldingsDto;
 import com.example.stock_system.ranking.RankingService;
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
+
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/accounts")
@@ -22,33 +23,33 @@ public class AccountController {
     private final RankingService rankingService;
 
 
-    @Operation(summary = "개인 계좌 생성",description = "비밀번호를 입력값으로 받아 개인 계좌를 생성해줍니다.")
+    @Operation(summary = "개인 계좌 생성", description = "비밀번호를 입력값으로 받아 개인 계좌를 생성해줍니다.")
     @PostMapping("/personal")
-    public ApiResponse<AccountDto> createPersonalAccount(@RequestBody CreateAccountRequest createAccountRequest){
-        Account savedAccount = accountService.createPersonalAccount(createAccountRequest.getName(),createAccountRequest.getUserId());
-        accountService.createAccountPInfo(savedAccount,createAccountRequest);
+    public ApiResponse<AccountDto> createPersonalAccount(@RequestBody CreateAccountRequest createAccountRequest) {
+        Account savedAccount = accountService.createPersonalAccount(createAccountRequest.getName(), createAccountRequest.getUserId());
+        accountService.createAccountPInfo(savedAccount, createAccountRequest);
         return new ApiResponse<>(201, true, "계좌가 생성되었습니다.", null);
     }
 
-    @Operation(summary = "팀 계좌 생성",description = "비밀번호를 입력값으로 받아 팀 계좌를 생성해줍니다.")
+    @Operation(summary = "팀 계좌 생성", description = "비밀번호를 입력값으로 받아 팀 계좌를 생성해줍니다.")
     @PostMapping("/team")
-    public ApiResponse<AccountDto> createTeamAccount(@RequestBody CreateAccountRequest createAccountRequest,@RequestAttribute("teamId") int teamId){
-        Account savedAccount = accountService.createTeamAccount(createAccountRequest.getName(),createAccountRequest.getUserId(),teamId);
-        accountService.createAccountPInfo(savedAccount,createAccountRequest);
+    public ApiResponse<AccountDto> createTeamAccount(@RequestBody CreateAccountRequest createAccountRequest, @RequestAttribute("teamId") int teamId) {
+        Account savedAccount = accountService.createTeamAccount(createAccountRequest.getName(), createAccountRequest.getUserId(), teamId);
+        accountService.createAccountPInfo(savedAccount, createAccountRequest);
         rankingService.registRanking(savedAccount);
         return new ApiResponse<>(201, true, "모임 계좌가 생성되었습니다.", null);
     }
 
-    @Operation(summary = "자동 이체 서비스",description = "test를 위해 호출식으로 작성, 추후에 배치로 처리")
+    @Operation(summary = "자동 이체 서비스", description = "test를 위해 호출식으로 작성, 추후에 배치로 처리")
     @PostMapping("/auto")
     public void autoPaymentAndExpel() {
-        List<AccountPayment> accountPayments= accountService.convertPaymentData();
+        List<AccountPayment> accountPayments = accountService.convertPaymentData();
         List<PayFail> payFails = accountService.autoPaymentService(accountPayments);
         accountService.expelMember(payFails);
 
     }
 
-    @Operation(summary = "실시간 계좌 보유 종목들의 각 data 조회",description = "실시간 데이터를 불러오는 API")
+    @Operation(summary = "실시간 계좌 보유 종목들의 각 data 조회", description = "실시간 데이터를 불러오는 API")
     @GetMapping(value = "/realtime/{teamId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<HoldingsDto> getRealTimeHoldingsByTeamId(@PathVariable int teamId) {
         return holdingsService.getRealTimeHoldingsByTeamId(teamId);
@@ -60,13 +61,13 @@ public class AccountController {
         return accountService.getRealTimeSumByTeamId(teamId);
     }
 
-    @Operation(summary = "자동 전량 매도 서비스",description = "test를 위해 호출식으로 작성, 추후에 배치로 처리")
+    @Operation(summary = "자동 전량 매도 서비스", description = "test를 위해 호출식으로 작성, 추후에 배치로 처리")
     @GetMapping("/all-stock-sell/{teamId}")
     public ApiResponse<Integer> allStockSell(@PathVariable int teamId) {
         int finishedTeam = accountService.allStockSell(teamId);
-        return new ApiResponse<>(200,true,"해당 계좌의 주식이 전량 매도 되었습니다.",finishedTeam);
+        return new ApiResponse<>(200, true, "해당 계좌의 주식이 전량 매도 되었습니다.", finishedTeam);
     }
-    
+
     @Operation(summary = "랭킹 업데이트", description = "test 위해 작성, 추후 배치 처리")
     @GetMapping("/update/ranking")
     public ApiResponse updateRanking() {
@@ -74,11 +75,17 @@ public class AccountController {
         return new ApiResponse<>(201, true, "랭킹 업데이트합니다.", null);
     }
 
-    @Operation(summary = "장 종료후 수익률체크",description = "최대 수익률 넘거나, 최소 수익률보다 낮으면 전량매도, 추후 배치로 바꿔야됨 test위해 컨트롤러로 처리")
+    @Operation(summary = "장 종료후 수익률체크", description = "최대 수익률 넘거나, 최소 수익률보다 낮으면 전량매도, 추후 배치로 바꿔야됨 test위해 컨트롤러로 처리")
     @GetMapping("/test")
     public ApiResponse test() throws JsonProcessingException {
         accountService.checkDisband();
-        return new ApiResponse<>(200,true,"해당 계좌의 주식이 전량 매도 되었습니다.",null);
+        return new ApiResponse<>(200, true, "해당 계좌의 주식이 전량 매도 되었습니다.", null);
+    }
+
+    @Operation(summary = "개인계좌 조회", description = "개인 계좌 조회")
+    @GetMapping("/personal")
+    public ApiResponse<GetPersonalAccountResponse> getPersonalAccount(@RequestAttribute("userId") int userId) {
+        return new ApiResponse<>(200, true, "개인 계좌 조회 성공", new GetPersonalAccountResponse().fromEntity(accountService.getPersonalAccount(userId)));
     }
 
 }

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountController.java
@@ -46,7 +46,6 @@ public class AccountController {
         List<AccountPayment> accountPayments = accountService.convertPaymentData();
         List<PayFail> payFails = accountService.autoPaymentService(accountPayments);
         accountService.expelMember(payFails);
-
     }
 
     @Operation(summary = "실시간 계좌 보유 종목들의 각 data 조회", description = "실시간 데이터를 불러오는 API")
@@ -86,6 +85,12 @@ public class AccountController {
     @GetMapping("/personal")
     public ApiResponse<GetPersonalAccountResponse> getPersonalAccount(@RequestAttribute("userId") int userId) {
         return new ApiResponse<>(200, true, "개인 계좌 조회 성공", new GetPersonalAccountResponse().fromEntity(accountService.getPersonalAccount(userId)));
+    }
+
+    @Operation(summary = "모임계좌 조회", description = "모임 계좌 조회")
+    @GetMapping("/team")
+    public ApiResponse<GetTeamAccountResponse> getTeamAccount(@RequestAttribute("teamId") int teamId) {
+        return new ApiResponse<>(200, true, "모임 계좌 조회 성공", new GetTeamAccountResponse().fromEntity(accountService.getTeamAccount(teamId)));
     }
 
 }

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
@@ -53,13 +53,13 @@ public class AccountService {
         return accountDtoConverter.fromEntity(account);
     }
 
-    public Account createTeamAccount(String name, int userId,int teamId) {
+    public Account createTeamAccount(String name, int userId, int teamId) {
 
         String accountNumber = "81902" + generateRandomNumber();
         Account account = new Account(name, userId, accountNumber);
         Account savedAccount = accountRepository.save(account);
 
-        TeamAccount teamAccount = new TeamAccount(savedAccount,teamId);
+        TeamAccount teamAccount = new TeamAccount(savedAccount, teamId);
         teamAccountRepository.save(teamAccount);
 
         List<Integer> failPaymentUser = processFirstPayment(teamId);
@@ -94,7 +94,7 @@ public class AccountService {
 
     public List<AccountPayment> convertPaymentData() {
 
-        String url = AG_URL+"/api/group/backend/auto-payment";
+        String url = AG_URL + "/api/group/backend/auto-payment";
 
         HttpHeaders httpHeaders = new HttpHeaders();
 
@@ -145,12 +145,10 @@ public class AccountService {
                 .filter(account -> account.getAccountNumber().startsWith("81901"))
                 .findFirst()
                 .orElseThrow(() -> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
-
-
     }
 
     public void expelMember(List<PayFail> payFails) {
-        String url = AG_URL+"/api/group/backend/expel-member";
+        String url = AG_URL + "/api/group/backend/expel-member";
 
 
         HttpHeaders httpHeaders = new HttpHeaders();
@@ -220,7 +218,7 @@ public class AccountService {
             // holdingsRepository.delete(holding);
         }
 
-        String url = AG_URL+"/api/group/backend/member";
+        String url = AG_URL + "/api/group/backend/member";
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
@@ -252,7 +250,7 @@ public class AccountService {
     }
 
     public FirstPayment getFirstPaymentFromAPI(int teamId) {
-        String url = AG_URL+"/api/group/backend/first-payment?teamId=" + teamId;
+        String url = AG_URL + "/api/group/backend/first-payment?teamId=" + teamId;
 
         ResponseEntity<ApiResponse> response = restTemplate.exchange(
                 url,
@@ -300,16 +298,18 @@ public class AccountService {
         }
         return failedUserIds;
     }
-  
+
     @Transactional
     public void checkDisband() throws JsonProcessingException {
-        String url = AG_URL+"/api/group/backend/rule-check";
+        String url = AG_URL + "/api/group/backend/rule-check";
         ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, null, String.class);
 
         ObjectMapper objectMapper = new ObjectMapper();
 
-        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), new TypeReference<Map<String, Object>>() {});
-        List<CheckDisband> checkDisbands = objectMapper.convertValue(responseBody.get("data"), new TypeReference<List<CheckDisband>>() {});
+        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), new TypeReference<Map<String, Object>>() {
+        });
+        List<CheckDisband> checkDisbands = objectMapper.convertValue(responseBody.get("data"), new TypeReference<List<CheckDisband>>() {
+        });
 
         for (CheckDisband checkDisband : checkDisbands) {
             TeamAccount teamAccount;
@@ -331,12 +331,12 @@ public class AccountService {
     }
 
     public void updateRanking() {
-        List<Account> accounts = accountRepository.findByAccountNumberStartingWith("81902").orElseThrow(()->new AccountException(AccountErrorCode.TEAM_ACCOUNT_NOT_FOUND));
+        List<Account> accounts = accountRepository.findByAccountNumberStartingWith("81902").orElseThrow(() -> new AccountException(AccountErrorCode.TEAM_ACCOUNT_NOT_FOUND));
 
         List<Ranking> rankings = rankingRepository.findByAccountIn(accounts).orElseThrow(() -> new RankingException(RankingErrorCode.RANKING_NOT_FOUNT));
         List<Ranking> updatedRankings = rankings.stream()
                 .map(ranking -> ranking.toBuilder()
-                        .seedMoney(ranking.getAccount().getDeposit()+ranking.getAccount().getTotalPchsAmt())
+                        .seedMoney(ranking.getAccount().getDeposit() + ranking.getAccount().getTotalPchsAmt())
                         .evluPflsRt(ranking.getAccount().getTotalEvluPflsRt())
                         .build())
                 .collect(Collectors.toList());

--- a/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/AccountService.java
@@ -147,6 +147,12 @@ public class AccountService {
                 .orElseThrow(() -> new AccountException(AccountErrorCode.ACCOUNT_NOT_FOUND));
     }
 
+    public Account getTeamAccount(int id) {
+        TeamAccount teamAccount = teamAccountRepository.findByTeamId(id)
+                .orElseThrow(() -> new AccountException(AccountErrorCode.TEAM_ACCOUNT_NOT_FOUND));
+        return teamAccount.getAccount();
+    }
+
     public void expelMember(List<PayFail> payFails) {
         String url = AG_URL + "/api/group/backend/expel-member";
 

--- a/stock-system/src/main/java/com/example/stock_system/account/dto/GetPersonalAccountResponse.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/dto/GetPersonalAccountResponse.java
@@ -1,0 +1,27 @@
+package com.example.stock_system.account.dto;
+
+import com.example.stock_system.account.Account;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GetPersonalAccountResponse {
+    private String accountNumber;
+    private int totalAsset;
+
+    public GetPersonalAccountResponse() {
+    }
+
+    @Builder
+    public GetPersonalAccountResponse(String accountNumber, int totalAsset) {
+        this.accountNumber = accountNumber;
+        this.totalAsset = totalAsset;
+    }
+
+    public GetPersonalAccountResponse fromEntity(Account account) {
+        return GetPersonalAccountResponse.builder()
+                .accountNumber(account.getAccountNumber())
+                .totalAsset(account.getDeposit() + account.getTotalEvluAmt())
+                .build();
+    }
+}

--- a/stock-system/src/main/java/com/example/stock_system/account/dto/GetTeamAccountResponse.java
+++ b/stock-system/src/main/java/com/example/stock_system/account/dto/GetTeamAccountResponse.java
@@ -1,5 +1,6 @@
 package com.example.stock_system.account.dto;
 
+import com.example.stock_system.account.Account;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -27,6 +28,17 @@ public class GetTeamAccountResponse {
         this.totalEvluPflsRt = totalEvluPflsRt;
         this.deposit = deposit;
         this.totalAsset = totalAsset;
+    }
 
+    public GetTeamAccountResponse fromEntity(Account account) {
+        return GetTeamAccountResponse.builder()
+                .accountNumber(account.getAccountNumber())
+                .totalPchsAmt(account.getTotalPchsAmt())
+                .totalEvluAmt(account.getTotalEvluAmt())
+                .totalEvluPfls(account.getTotalEvluPfls())
+                .totalEvluPflsRt(account.getTotalEvluPflsRt())
+                .deposit(account.getDeposit())
+                .totalAsset(account.getDeposit() + account.getTotalEvluAmt())
+                .build();
     }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 개인 계좌 조회와 모임 계좌 조회 api를 분리합니다.

### 테스트 결과
- 개인 계좌 조회
<img width="785" alt="image" src="https://github.com/user-attachments/assets/52f49e0c-241f-4b85-ad90-27112134cb25">

- 모임 계좌 조회
<img width="784" alt="image" src="https://github.com/user-attachments/assets/2316bbc7-e91d-4e3d-b03a-f13661821137">
