### PR TITLE
절대경로로 파일 불러오게 변경

### DIFF
--- a/alarm/src/main/java/com/example/alarm/firebase/FCMInitializer.java
+++ b/alarm/src/main/java/com/example/alarm/firebase/FCMInitializer.java
@@ -6,9 +6,9 @@ import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -22,10 +22,7 @@ public class FCMInitializer {
     // 빈 객체가 생성되고 의존성 주입이 완료된 후에 초기화가 실행될 수 있도록
     @PostConstruct
     public void initialize() {
-
-        ClassPathResource resource = new ClassPathResource(googleApplicationCredentials);
-
-        try (InputStream is = resource.getInputStream()) {
+        try (InputStream is = new FileInputStream(googleApplicationCredentials)) {
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(is))
                     .build();


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
EC2에서 외부 파일을 불러와 빌드 할 수 있게 절대경로로 파일을 불러오게 설정

### 테스트 결과

